### PR TITLE
BUZZ-191: Rename provider module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module leanspace-terraform-provider
+module github.com/leanspace/terraform-provider-leanspace
 
 go 1.18
 

--- a/helper/general_objects/models.go
+++ b/helper/general_objects/models.go
@@ -1,6 +1,6 @@
 package general_objects
 
-import "leanspace-terraform-provider/helper"
+import "github.com/leanspace/terraform-provider-leanspace/helper"
 
 type Sort struct {
 	Direction    string `json:"direction"`

--- a/helper/general_objects/parsers.go
+++ b/helper/general_objects/parsers.go
@@ -1,8 +1,9 @@
 package general_objects
 
 import (
-	"leanspace-terraform-provider/helper"
 	"strconv"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 )
 
 func (paginatedList *PaginatedList[T, PT]) ToMap() map[string]any {

--- a/helper/general_objects/schemas.go
+++ b/helper/general_objects/schemas.go
@@ -1,7 +1,7 @@
 package general_objects
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/main.go
+++ b/main.go
@@ -1,36 +1,35 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"leanspace-terraform-provider/provider"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 
-	"leanspace-terraform-provider/services/activities/activity_definitions"
-	"leanspace-terraform-provider/services/agents/remote_agents"
-	"leanspace-terraform-provider/services/analyses/analysis_definitions"
-	"leanspace-terraform-provider/services/asset/nodes"
-	"leanspace-terraform-provider/services/asset/properties"
-	"leanspace-terraform-provider/services/asset/units"
-	"leanspace-terraform-provider/services/commands/command_definitions"
-	"leanspace-terraform-provider/services/commands/command_queues"
-	"leanspace-terraform-provider/services/dashboard/dashboards"
-	"leanspace-terraform-provider/services/dashboard/widgets"
-	"leanspace-terraform-provider/services/metrics/metrics"
-	"leanspace-terraform-provider/services/monitors/action_templates"
-	"leanspace-terraform-provider/services/monitors/monitors"
-	"leanspace-terraform-provider/services/plugins/plugins"
-	"leanspace-terraform-provider/services/streams/streams"
-	"leanspace-terraform-provider/services/teams/access_policies"
-	"leanspace-terraform-provider/services/teams/members"
-	"leanspace-terraform-provider/services/teams/service_accounts"
-	"leanspace-terraform-provider/services/teams/teams"
+	"github.com/leanspace/terraform-provider-leanspace/services/activities/activity_definitions"
+	"github.com/leanspace/terraform-provider-leanspace/services/agents/remote_agents"
+	"github.com/leanspace/terraform-provider-leanspace/services/analyses/analysis_definitions"
+	"github.com/leanspace/terraform-provider-leanspace/services/asset/nodes"
+	"github.com/leanspace/terraform-provider-leanspace/services/asset/properties"
+	"github.com/leanspace/terraform-provider-leanspace/services/asset/units"
+	"github.com/leanspace/terraform-provider-leanspace/services/commands/command_definitions"
+	"github.com/leanspace/terraform-provider-leanspace/services/commands/command_queues"
+	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/dashboards"
+	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/widgets"
+	"github.com/leanspace/terraform-provider-leanspace/services/metrics/metrics"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/monitors"
+	"github.com/leanspace/terraform-provider-leanspace/services/plugins/plugins"
+	"github.com/leanspace/terraform-provider-leanspace/services/streams/streams"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/access_policies"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/members"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/service_accounts"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/teams"
 )
 
 // Generate the Terraform provider documentation using `tfplugindocs`:
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-func main() {
+func AddDataTypes() {
 	access_policies.AccessPolicyDataType.Subscribe()
 	action_templates.ActionTemplateDataType.Subscribe()
 	activity_definitions.ActivityDefinitionDataType.Subscribe()
@@ -50,10 +49,11 @@ func main() {
 	teams.TeamDataType.Subscribe()
 	units.UnitDataType.Subscribe()
 	widgets.WidgetDataType.Subscribe()
+}
 
+func main() {
+	AddDataTypes()
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: func() *schema.Provider {
-			return provider.Provider()
-		},
+		ProviderFunc: provider.Provider,
 	})
 }

--- a/provider/generic_client.go
+++ b/provider/generic_client.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 )
 
 func (client GenericClient[T, PT]) marshalElement(element PT) ([]byte, error) {

--- a/provider/generic_data_source.go
+++ b/provider/generic_data_source.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 )
 
 func (dataSourceType DataSourceType[T, PT]) toDataSource() *schema.Resource {

--- a/provider/generic_resource.go
+++ b/provider/generic_resource.go
@@ -2,7 +2,8 @@ package provider
 
 import (
 	"context"
-	"leanspace-terraform-provider/helper"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/provider/parser_mapping.go
+++ b/provider/parser_mapping.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"io"
 
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/activities/activity_definitions/main.go
+++ b/services/activities/activity_definitions/main.go
@@ -1,6 +1,6 @@
 package activity_definitions
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var ActivityDefinitionDataType = provider.DataSourceType[ActivityDefinition, *ActivityDefinition]{
 	ResourceIdentifier: "leanspace_activity_definitions",

--- a/services/activities/activity_definitions/models.go
+++ b/services/activities/activity_definitions/models.go
@@ -1,6 +1,6 @@
 package activity_definitions
 
-import "leanspace-terraform-provider/helper/general_objects"
+import "github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 type ActivityDefinition struct {
 	ID                  string                    `json:"id"`

--- a/services/activities/activity_definitions/parsers.go
+++ b/services/activities/activity_definitions/parsers.go
@@ -1,7 +1,7 @@
 package activity_definitions
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/activities/activity_definitions/schemas.go
+++ b/services/activities/activity_definitions/schemas.go
@@ -1,7 +1,7 @@
 package activity_definitions
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/agents/remote_agents/main.go
+++ b/services/agents/remote_agents/main.go
@@ -1,6 +1,6 @@
 package remote_agents
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var RemoteAgentDataType = provider.DataSourceType[RemoteAgent, *RemoteAgent]{
 	ResourceIdentifier: "leanspace_remote_agents",

--- a/services/agents/remote_agents/parsers.go
+++ b/services/agents/remote_agents/parsers.go
@@ -1,7 +1,7 @@
 package remote_agents
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/agents/remote_agents/requests.go
+++ b/services/agents/remote_agents/requests.go
@@ -3,8 +3,9 @@ package remote_agents
 import (
 	"encoding/json"
 	"fmt"
-	"leanspace-terraform-provider/provider"
 	"net/http"
+
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 // Cleanup function needed because an access policy and a service account are created

--- a/services/agents/remote_agents/schemas.go
+++ b/services/agents/remote_agents/schemas.go
@@ -1,7 +1,7 @@
 package remote_agents
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/agents/remote_agents/validation.go
+++ b/services/agents/remote_agents/validation.go
@@ -1,7 +1,7 @@
 package remote_agents
 
 import (
-	. "leanspace-terraform-provider/helper"
+	. "github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/analyses/analysis_definitions/main.go
+++ b/services/analyses/analysis_definitions/main.go
@@ -1,6 +1,6 @@
 package analysis_definitions
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var AnalysisDefinitionDataType = provider.DataSourceType[AnalysisDefinition, *AnalysisDefinition]{
 	ResourceIdentifier: "leanspace_analysis_definitions",

--- a/services/analyses/analysis_definitions/parsers.go
+++ b/services/analyses/analysis_definitions/parsers.go
@@ -3,8 +3,9 @@ package analysis_definitions
 import (
 	"encoding/json"
 	"fmt"
-	"leanspace-terraform-provider/helper"
 	"strings"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/analyses/analysis_definitions/schemas.go
+++ b/services/analyses/analysis_definitions/schemas.go
@@ -1,8 +1,9 @@
 package analysis_definitions
 
 import (
-	"leanspace-terraform-provider/helper"
 	"regexp"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/analyses/analysis_definitions/validation.go
+++ b/services/analyses/analysis_definitions/validation.go
@@ -1,7 +1,7 @@
 package analysis_definitions
 
 import (
-	. "leanspace-terraform-provider/helper"
+	. "github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/asset/nodes/main.go
+++ b/services/asset/nodes/main.go
@@ -1,6 +1,6 @@
 package nodes
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var NodeDataType = provider.DataSourceType[Node, *Node]{
 	ResourceIdentifier: "leanspace_nodes",

--- a/services/asset/nodes/models.go
+++ b/services/asset/nodes/models.go
@@ -1,6 +1,6 @@
 package nodes
 
-import "leanspace-terraform-provider/helper/general_objects"
+import "github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 type Node struct {
 	ID                      string                `json:"id"`

--- a/services/asset/nodes/parsers.go
+++ b/services/asset/nodes/parsers.go
@@ -1,8 +1,8 @@
 package nodes
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/asset/nodes/schemas.go
+++ b/services/asset/nodes/schemas.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 )
 
 var nodeSchema = makeNodeSchema(nil)            // no sub nodes

--- a/services/asset/nodes/validation.go
+++ b/services/asset/nodes/validation.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	. "leanspace-terraform-provider/helper"
+	. "github.com/leanspace/terraform-provider-leanspace/helper"
 )
 
 var tle1stLineRegex = regexp.MustCompile(`^1 (?P<noradId>[ 0-9]{5})[A-Z] [ 0-9]{5}[ A-Z]{3} [ 0-9]{5}[.][ 0-9]{8} (?:(?:[ 0+-][.][ 0-9]{8})|(?: [ +-][.][ 0-9]{7})) [ +-][ 0-9]{5}[+-][ 0-9] [ +-][ 0-9]{5}[+-][ 0-9] [ 0-9] [ 0-9]{4}[ 0-9]$`)

--- a/services/asset/properties/main.go
+++ b/services/asset/properties/main.go
@@ -2,7 +2,8 @@ package properties
 
 import (
 	"fmt"
-	"leanspace-terraform-provider/provider"
+
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 var PropertyDataType = provider.DataSourceType[Property[any], *Property[any]]{

--- a/services/asset/properties/models.go
+++ b/services/asset/properties/models.go
@@ -1,6 +1,6 @@
 package properties
 
-import "leanspace-terraform-provider/helper/general_objects"
+import "github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 type Property[T any] struct {
 	ID             string                `json:"id"`

--- a/services/asset/properties/parsers.go
+++ b/services/asset/properties/parsers.go
@@ -1,9 +1,10 @@
 package properties
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
 	"strconv"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/asset/properties/schemas.go
+++ b/services/asset/properties/schemas.go
@@ -4,8 +4,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 )
 
 var validPropertyTypes = []string{"NUMERIC", "ENUM", "TEXT", "TIMESTAMP", "DATE", "TIME", "BOOLEAN", "GEOPOINT"}

--- a/services/asset/properties/validation.go
+++ b/services/asset/properties/validation.go
@@ -1,7 +1,7 @@
 package properties
 
 import (
-	. "leanspace-terraform-provider/helper"
+	. "github.com/leanspace/terraform-provider-leanspace/helper"
 )
 
 var propertyValidators = Validators{

--- a/services/asset/units/main.go
+++ b/services/asset/units/main.go
@@ -1,7 +1,7 @@
 package units
 
 import (
-	"leanspace-terraform-provider/provider"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 var UnitDataType = provider.DataSourceType[Unit, *Unit]{

--- a/services/commands/command_definitions/main.go
+++ b/services/commands/command_definitions/main.go
@@ -1,6 +1,6 @@
 package command_definitions
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var CommandDataType = provider.DataSourceType[CommandDefinition, *CommandDefinition]{
 	ResourceIdentifier: "leanspace_command_definitions",

--- a/services/commands/command_definitions/models.go
+++ b/services/commands/command_definitions/models.go
@@ -1,6 +1,6 @@
 package command_definitions
 
-import "leanspace-terraform-provider/helper/general_objects"
+import "github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 type CommandDefinition struct {
 	ID             string          `json:"id"`

--- a/services/commands/command_definitions/parsers.go
+++ b/services/commands/command_definitions/parsers.go
@@ -1,7 +1,7 @@
 package command_definitions
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/commands/command_definitions/schemas.go
+++ b/services/commands/command_definitions/schemas.go
@@ -1,7 +1,7 @@
 package command_definitions
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/commands/command_queues/main.go
+++ b/services/commands/command_queues/main.go
@@ -1,6 +1,6 @@
 package command_queues
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var CommandQueueDataType = provider.DataSourceType[CommandQueue, *CommandQueue]{
 	ResourceIdentifier: "leanspace_command_queues",

--- a/services/dashboard/dashboards/main.go
+++ b/services/dashboard/dashboards/main.go
@@ -1,6 +1,6 @@
 package dashboards
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var DashboardDataType = provider.DataSourceType[Dashboard, *Dashboard]{
 	ResourceIdentifier: "leanspace_dashboards",

--- a/services/dashboard/dashboards/models.go
+++ b/services/dashboard/dashboards/models.go
@@ -1,8 +1,8 @@
 package dashboards
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
-	"leanspace-terraform-provider/services/dashboard/widgets"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/widgets"
 )
 
 type Dashboard struct {

--- a/services/dashboard/dashboards/parsers.go
+++ b/services/dashboard/dashboards/parsers.go
@@ -1,9 +1,9 @@
 package dashboards
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
-	"leanspace-terraform-provider/services/dashboard/widgets"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/widgets"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/dashboard/dashboards/requests.go
+++ b/services/dashboard/dashboards/requests.go
@@ -3,10 +3,11 @@ package dashboards
 import (
 	"encoding/json"
 	"fmt"
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/provider"
 	"net/http"
 	"strings"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 type apiValidWidgetInfo struct {

--- a/services/dashboard/dashboards/schemas.go
+++ b/services/dashboard/dashboards/schemas.go
@@ -1,12 +1,12 @@
 package dashboards
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 )
 
 var validWidgetTypes = []string{"TABLE", "LINE", "BAR", "AREA", "VALUE"}

--- a/services/dashboard/widgets/main.go
+++ b/services/dashboard/widgets/main.go
@@ -1,6 +1,6 @@
 package widgets
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var WidgetDataType = provider.DataSourceType[Widget, *Widget]{
 	ResourceIdentifier: "leanspace_widgets",

--- a/services/dashboard/widgets/models.go
+++ b/services/dashboard/widgets/models.go
@@ -1,6 +1,6 @@
 package widgets
 
-import "leanspace-terraform-provider/helper/general_objects"
+import "github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 type Widget struct {
 	ID             string                `json:"id"`

--- a/services/dashboard/widgets/parsers.go
+++ b/services/dashboard/widgets/parsers.go
@@ -1,8 +1,8 @@
 package widgets
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/dashboard/widgets/schemas.go
+++ b/services/dashboard/widgets/schemas.go
@@ -1,9 +1,9 @@
 package widgets
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/metrics/metrics/main.go
+++ b/services/metrics/metrics/main.go
@@ -1,6 +1,6 @@
 package metrics
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var MetricDataType = provider.DataSourceType[Metric[any], *Metric[any]]{
 	ResourceIdentifier: "leanspace_metrics",

--- a/services/metrics/metrics/models.go
+++ b/services/metrics/metrics/models.go
@@ -1,6 +1,6 @@
 package metrics
 
-import "leanspace-terraform-provider/helper/general_objects"
+import "github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 type Metric[T any] struct {
 	ID             string                                 `json:"id"`

--- a/services/metrics/metrics/parsers.go
+++ b/services/metrics/metrics/parsers.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/metrics/metrics/schemas.go
+++ b/services/metrics/metrics/schemas.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/monitors/action_templates/main.go
+++ b/services/monitors/action_templates/main.go
@@ -1,6 +1,6 @@
 package action_templates
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var ActionTemplateDataType = provider.DataSourceType[ActionTemplate, *ActionTemplate]{
 	ResourceIdentifier: "leanspace_action_templates",

--- a/services/monitors/action_templates/schemas.go
+++ b/services/monitors/action_templates/schemas.go
@@ -1,7 +1,7 @@
 package action_templates
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/monitors/monitors/main.go
+++ b/services/monitors/monitors/main.go
@@ -1,6 +1,6 @@
 package monitors
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var MonitorDataType = provider.DataSourceType[Monitor, *Monitor]{
 	ResourceIdentifier: "leanspace_monitors",

--- a/services/monitors/monitors/models.go
+++ b/services/monitors/monitors/models.go
@@ -1,8 +1,8 @@
 package monitors
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
-	"leanspace-terraform-provider/services/monitors/action_templates"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
 )
 
 type Monitor struct {

--- a/services/monitors/monitors/parsers.go
+++ b/services/monitors/monitors/parsers.go
@@ -1,9 +1,9 @@
 package monitors
 
 import (
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/helper/general_objects"
-	"leanspace-terraform-provider/services/monitors/action_templates"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/monitors/monitors/requests.go
+++ b/services/monitors/monitors/requests.go
@@ -2,9 +2,10 @@ package monitors
 
 import (
 	"fmt"
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/provider"
 	"net/http"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 func (monitor *Monitor) actionTemplateChange(action string, actionTemplateId string, client *provider.Client) error {

--- a/services/monitors/monitors/schemas.go
+++ b/services/monitors/monitors/schemas.go
@@ -1,10 +1,10 @@
 package monitors
 
 import (
-	"leanspace-terraform-provider/helper/general_objects"
-	"leanspace-terraform-provider/services/monitors/action_templates"
+	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
 
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/monitors/monitors/validation.go
+++ b/services/monitors/monitors/validation.go
@@ -1,7 +1,7 @@
 package monitors
 
 import (
-	. "leanspace-terraform-provider/helper"
+	. "github.com/leanspace/terraform-provider-leanspace/helper"
 )
 
 var monitorExpressionValidators = Validators{

--- a/services/plugins/plugins/main.go
+++ b/services/plugins/plugins/main.go
@@ -2,7 +2,8 @@ package plugins
 
 import (
 	"fmt"
-	"leanspace-terraform-provider/provider"
+
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 var PluginDataType = provider.DataSourceType[Plugin, *Plugin]{

--- a/services/plugins/plugins/parsers.go
+++ b/services/plugins/plugins/parsers.go
@@ -1,6 +1,6 @@
 package plugins
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 func (plugin *Plugin) ToMap() map[string]any {
 	pluginMap := make(map[string]any)

--- a/services/plugins/plugins/schemas.go
+++ b/services/plugins/plugins/schemas.go
@@ -1,8 +1,9 @@
 package plugins
 
 import (
-	"leanspace-terraform-provider/helper"
 	"regexp"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/streams/streams/main.go
+++ b/services/streams/streams/main.go
@@ -1,6 +1,6 @@
 package streams
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var StreamDataType = provider.DataSourceType[Stream, *Stream]{
 	ResourceIdentifier: "leanspace_streams",

--- a/services/streams/streams/models.go
+++ b/services/streams/streams/models.go
@@ -1,6 +1,6 @@
 package streams
 
-import "leanspace-terraform-provider/helper"
+import "github.com/leanspace/terraform-provider-leanspace/helper"
 
 type Stream struct {
 	ID             string        `json:"id"`

--- a/services/streams/streams/parsers.go
+++ b/services/streams/streams/parsers.go
@@ -2,8 +2,9 @@ package streams
 
 import (
 	"encoding/base64"
-	"leanspace-terraform-provider/helper"
 	"strconv"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/services/streams/streams/schemas.go
+++ b/services/streams/streams/schemas.go
@@ -1,7 +1,7 @@
 package streams
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/streams/streams/validation.go
+++ b/services/streams/streams/validation.go
@@ -1,7 +1,7 @@
 package streams
 
 import (
-	. "leanspace-terraform-provider/helper"
+	. "github.com/leanspace/terraform-provider-leanspace/helper"
 )
 
 var streamComponentValidators = Validators{

--- a/services/teams/access_policies/main.go
+++ b/services/teams/access_policies/main.go
@@ -1,6 +1,6 @@
 package access_policies
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var AccessPolicyDataType = provider.DataSourceType[AccessPolicy, *AccessPolicy]{
 	ResourceIdentifier: "leanspace_access_policies",

--- a/services/teams/access_policies/parsers.go
+++ b/services/teams/access_policies/parsers.go
@@ -1,6 +1,6 @@
 package access_policies
 
-import "leanspace-terraform-provider/helper"
+import "github.com/leanspace/terraform-provider-leanspace/helper"
 
 func (policy *AccessPolicy) ToMap() map[string]any {
 	policyMap := make(map[string]any)

--- a/services/teams/members/main.go
+++ b/services/teams/members/main.go
@@ -1,6 +1,6 @@
 package members
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var MemberDataType = provider.DataSourceType[Member, *Member]{
 	ResourceIdentifier: "leanspace_members",

--- a/services/teams/members/requests.go
+++ b/services/teams/members/requests.go
@@ -3,10 +3,11 @@ package members
 import (
 	"encoding/json"
 	"fmt"
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/provider"
 	"net/http"
 	"strings"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 func (member *Member) currentPolicies(client *provider.Client) ([]string, error) {

--- a/services/teams/members/schemas.go
+++ b/services/teams/members/schemas.go
@@ -1,7 +1,7 @@
 package members
 
 import (
-	"leanspace-terraform-provider/helper"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/services/teams/service_accounts/main.go
+++ b/services/teams/service_accounts/main.go
@@ -1,6 +1,6 @@
 package service_accounts
 
-import "leanspace-terraform-provider/provider"
+import "github.com/leanspace/terraform-provider-leanspace/provider"
 
 var ServiceAccountDataType = provider.DataSourceType[ServiceAccount, *ServiceAccount]{
 	ResourceIdentifier: "leanspace_service_accounts",

--- a/services/teams/service_accounts/requests.go
+++ b/services/teams/service_accounts/requests.go
@@ -3,10 +3,11 @@ package service_accounts
 import (
 	"encoding/json"
 	"fmt"
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/provider"
 	"net/http"
 	"strings"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 func (serviceAccount *ServiceAccount) currentPolicies(client *provider.Client) ([]string, error) {

--- a/services/teams/teams/main.go
+++ b/services/teams/teams/main.go
@@ -1,7 +1,7 @@
 package teams
 
 import (
-	"leanspace-terraform-provider/provider"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 var TeamDataType = provider.DataSourceType[Team, *Team]{

--- a/services/teams/teams/requests.go
+++ b/services/teams/teams/requests.go
@@ -3,10 +3,11 @@ package teams
 import (
 	"encoding/json"
 	"fmt"
-	"leanspace-terraform-provider/helper"
-	"leanspace-terraform-provider/provider"
 	"net/http"
 	"strings"
+
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
 func (team *Team) currentPolicies(client *provider.Client) ([]string, error) {


### PR DESCRIPTION
- Renamed `leanspace-terraform-provider` -> `github.com/leanspace/terraform-provider-leanspace`
- Minor change to `main.go`, to allow loading all resources without serving the provider.