### PR TITLE
BUZZ-191: Move data type subscribing to separate file

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,55 +4,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/leanspace/terraform-provider-leanspace/provider"
-
-	"github.com/leanspace/terraform-provider-leanspace/services/activities/activity_definitions"
-	"github.com/leanspace/terraform-provider-leanspace/services/agents/remote_agents"
-	"github.com/leanspace/terraform-provider-leanspace/services/analyses/analysis_definitions"
-	"github.com/leanspace/terraform-provider-leanspace/services/asset/nodes"
-	"github.com/leanspace/terraform-provider-leanspace/services/asset/properties"
-	"github.com/leanspace/terraform-provider-leanspace/services/asset/units"
-	"github.com/leanspace/terraform-provider-leanspace/services/commands/command_definitions"
-	"github.com/leanspace/terraform-provider-leanspace/services/commands/command_queues"
-	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/dashboards"
-	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/widgets"
-	"github.com/leanspace/terraform-provider-leanspace/services/metrics/metrics"
-	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
-	"github.com/leanspace/terraform-provider-leanspace/services/monitors/monitors"
-	"github.com/leanspace/terraform-provider-leanspace/services/plugins/plugins"
-	"github.com/leanspace/terraform-provider-leanspace/services/streams/streams"
-	"github.com/leanspace/terraform-provider-leanspace/services/teams/access_policies"
-	"github.com/leanspace/terraform-provider-leanspace/services/teams/members"
-	"github.com/leanspace/terraform-provider-leanspace/services/teams/service_accounts"
-	"github.com/leanspace/terraform-provider-leanspace/services/teams/teams"
+	"github.com/leanspace/terraform-provider-leanspace/services"
 )
 
 // Generate the Terraform provider documentation using `tfplugindocs`:
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-func AddDataTypes() {
-	access_policies.AccessPolicyDataType.Subscribe()
-	action_templates.ActionTemplateDataType.Subscribe()
-	activity_definitions.ActivityDefinitionDataType.Subscribe()
-	analysis_definitions.AnalysisDefinitionDataType.Subscribe()
-	command_definitions.CommandDataType.Subscribe()
-	command_queues.CommandQueueDataType.Subscribe()
-	dashboards.DashboardDataType.Subscribe()
-	members.MemberDataType.Subscribe()
-	metrics.MetricDataType.Subscribe()
-	monitors.MonitorDataType.Subscribe()
-	nodes.NodeDataType.Subscribe()
-	plugins.PluginDataType.Subscribe()
-	properties.PropertyDataType.Subscribe()
-	remote_agents.RemoteAgentDataType.Subscribe()
-	service_accounts.ServiceAccountDataType.Subscribe()
-	streams.StreamDataType.Subscribe()
-	teams.TeamDataType.Subscribe()
-	units.UnitDataType.Subscribe()
-	widgets.WidgetDataType.Subscribe()
-}
-
 func main() {
-	AddDataTypes()
+	services.AddDataTypes()
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: provider.Provider,
 	})

--- a/services/importer.go
+++ b/services/importer.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"github.com/leanspace/terraform-provider-leanspace/services/activities/activity_definitions"
+	"github.com/leanspace/terraform-provider-leanspace/services/agents/remote_agents"
+	"github.com/leanspace/terraform-provider-leanspace/services/analyses/analysis_definitions"
+	"github.com/leanspace/terraform-provider-leanspace/services/asset/nodes"
+	"github.com/leanspace/terraform-provider-leanspace/services/asset/properties"
+	"github.com/leanspace/terraform-provider-leanspace/services/asset/units"
+	"github.com/leanspace/terraform-provider-leanspace/services/commands/command_definitions"
+	"github.com/leanspace/terraform-provider-leanspace/services/commands/command_queues"
+	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/dashboards"
+	"github.com/leanspace/terraform-provider-leanspace/services/dashboard/widgets"
+	"github.com/leanspace/terraform-provider-leanspace/services/metrics/metrics"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
+	"github.com/leanspace/terraform-provider-leanspace/services/monitors/monitors"
+	"github.com/leanspace/terraform-provider-leanspace/services/plugins/plugins"
+	"github.com/leanspace/terraform-provider-leanspace/services/streams/streams"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/access_policies"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/members"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/service_accounts"
+	"github.com/leanspace/terraform-provider-leanspace/services/teams/teams"
+)
+
+func AddDataTypes() {
+	access_policies.AccessPolicyDataType.Subscribe()
+	action_templates.ActionTemplateDataType.Subscribe()
+	activity_definitions.ActivityDefinitionDataType.Subscribe()
+	analysis_definitions.AnalysisDefinitionDataType.Subscribe()
+	command_definitions.CommandDataType.Subscribe()
+	command_queues.CommandQueueDataType.Subscribe()
+	dashboards.DashboardDataType.Subscribe()
+	members.MemberDataType.Subscribe()
+	metrics.MetricDataType.Subscribe()
+	monitors.MonitorDataType.Subscribe()
+	nodes.NodeDataType.Subscribe()
+	plugins.PluginDataType.Subscribe()
+	properties.PropertyDataType.Subscribe()
+	remote_agents.RemoteAgentDataType.Subscribe()
+	service_accounts.ServiceAccountDataType.Subscribe()
+	streams.StreamDataType.Subscribe()
+	teams.TeamDataType.Subscribe()
+	units.UnitDataType.Subscribe()
+	widgets.WidgetDataType.Subscribe()
+}


### PR DESCRIPTION
A simple move, that both helps keep the `main` package simple, and allows for the importing of this package in other modules (otherwise it didn't work, for some reason).