### PR TITLE
SDEVOPS-358 - Improving terraform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       -
         name: Tag Validation
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.TERRAFORM_RELEASE_VAR_UPDATE_TOKEN }}
         run: |
           CURRENT_RELEASE_VERSION=$(gh api -H "Accept: application/vnd.github+json" /repos/leanspace/testing-workflows/actions/variables/RELEASE_VERSION | jq -r .value | awk -F 'v' '{ print $NF }')
           NEW_RELEASE_VERSION=$( echo ${{ github.event.inputs.release-version }} | awk -F 'v' '{ print $NF }')
@@ -140,7 +140,7 @@ jobs:
       -
         name: Updating RELEASE_VERSION variable
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.TERRAFORM_RELEASE_VAR_UPDATE_TOKEN }}
         run: |
           echo "[#] Updating the repository variable RELEASE_VERSION with the new version."
           gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/leanspace/testing-workflows/actions/variables/RELEASE_VERSION \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           git config --global user.email 'leanspace-bot@users.noreply.github.com'
           git status
           git add -A
-          git commit -m "Update docs"
+          git commit --allow-empty -m "Update docs"
           git tag ${{ github.event.inputs.release-version }} HEAD
           git push --follow-tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TERRAFORM_RELEASE_VAR_UPDATE_TOKEN }}
         run: |
-          CURRENT_RELEASE_VERSION=$(gh api -H "Accept: application/vnd.github+json" /repos/leanspace/testing-workflows/actions/variables/RELEASE_VERSION | jq -r .value | awk -F 'v' '{ print $NF }')
+          CURRENT_RELEASE_VERSION=$(gh api -H "Accept: application/vnd.github+json" /repos/leanspace/terraform-provider-leanspace/actions/variables/RELEASE_VERSION | jq -r .value | awk -F 'v' '{ print $NF }')
           NEW_RELEASE_VERSION=$( echo ${{ github.event.inputs.release-version }} | awk -F 'v' '{ print $NF }')
           RELEASE_TYPE=$( echo ${{ github.event.inputs.release-type }} | awk -F 'v' '{ print $NF }')
 
@@ -143,6 +143,6 @@ jobs:
           GH_TOKEN: ${{ secrets.TERRAFORM_RELEASE_VAR_UPDATE_TOKEN }}
         run: |
           echo "[#] Updating the repository variable RELEASE_VERSION with the new version."
-          gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/leanspace/testing-workflows/actions/variables/RELEASE_VERSION \
+          gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/leanspace/terraform-provider-leanspace/actions/variables/RELEASE_VERSION \
           -f name='RELEASE_VERSION' \
           -f value="${{ github.event.inputs.release-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,76 @@
-name: release
+name: Terraform Provider Release Deployer
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Specify the release version to deploy : v{marjor}.{minor}.{patch}'
+        required: true
+        type: string
+      release-type:
+        description: 'Specify the release type major/minor/patch [patch]'
+        required: true
+        type: choice
+        options:
+          - "major"
+          - "minor"
+          - "patch"
+        default: "patch"
 
 jobs:
-  release:
+  version-validation:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout Repository
+        uses: actions/checkout@v3
+
+      -
+        name: Tag Validation
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          CURRENT_RELEASE_VERSION=$(gh api -H "Accept: application/vnd.github+json" /repos/leanspace/testing-workflows/actions/variables/RELEASE_VERSION | jq -r .value | awk -F 'v' '{ print $NF }')
+          NEW_RELEASE_VERSION=$( echo ${{ github.event.inputs.release-version }} | awk -F 'v' '{ print $NF }')
+          RELEASE_TYPE=$( echo ${{ github.event.inputs.release-type }} | awk -F 'v' '{ print $NF }')
+
+          ### Tag Validation Function ###
+          tag_validator_function()
+          {
+          if echo "${{ github.event.inputs.release-version }}" | grep 'v[0-9]*\.[0-9]*\.[0-9]*' > /dev/null
+            then
+              echo "[#] Version tag format is correct. Moving on....."
+            else
+              echo "[!] Version tag format ${{ github.event.inputs.release-version }} invalid!"
+              echo "[!] Expected format: v0.0.0"
+              exit 1
+            fi
+          if [[ ${NEW_RELEASE_VERSION} != ${EXPECTED_RELEASE_VERSION} ]]
+            then
+              echo "[!] Invalid ${1} release version v${NEW_RELEASE_VERSION} where it should be v${EXPECTED_RELEASE_VERSION}"
+              echo "[-] Current Release Version: v${CURRENT_RELEASE_VERSION}"
+              echo "[+] New Release Version: v${NEW_RELEASE_VERSION}"
+              exit 1
+            else
+              echo "[+] New ${1} release version v${NEW_RELEASE_VERSION} is valid."
+              echo "[-] Current Release Version: v${CURRENT_RELEASE_VERSION}"
+              echo "[+] New Release Version: v${NEW_RELEASE_VERSION}"
+          fi
+          }
+          ### Tag Validation Function ###
+
+          case ${RELEASE_TYPE} in
+            patch)
+              EXPECTED_RELEASE_VERSION=$(scripts/version-incrementer.sh -p ${CURRENT_RELEASE_VERSION})
+              tag_validator_function "patch";;
+            minor)
+              EXPECTED_RELEASE_VERSION=$(scripts/version-incrementer.sh -m ${CURRENT_RELEASE_VERSION})
+              tag_validator_function "minor";;
+            major)
+              EXPECTED_RELEASE_VERSION=$(scripts/version-incrementer.sh -M ${CURRENT_RELEASE_VERSION})
+              tag_validator_function "major";;
+          esac
+
+  release-deployer:
     runs-on: ubuntu-latest
     steps:
       -
@@ -40,6 +105,7 @@ jobs:
         run: |
           cd terraform-provider-leanspace
           go generate
+
       -
         name: Commit and push
         run: |
@@ -48,8 +114,15 @@ jobs:
           git config --global user.email 'leanspace-bot@users.noreply.github.com'
           git status
           git add -A
-          git diff-index --quiet HEAD || git commit -m "Update docs"
-          git push
+          git commit -m "Update docs"
+          if git diff-index --quiet HEAD
+            then
+              git tag ${{ github.event.inputs.release-version }} HEAD
+              git push --follow-tags
+            else
+              echo "[!] No changes detected. Exiting....."
+              exit 1
+          fi
 
       -
         name: Run GoReleaser
@@ -63,3 +136,13 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Updating RELEASE_VERSION variable
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          echo "[#] Updating the repository variable RELEASE_VERSION with the new version."
+          gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/leanspace/testing-workflows/actions/variables/RELEASE_VERSION \
+          -f name='RELEASE_VERSION' \
+          -f value="${{ github.event.inputs.release-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           go generate
 
       -
-        name: Commit and push
+        name: Commit tag and push
         run: |
           cd terraform-provider-leanspace
           git config --global user.name 'leanspace-bot'
@@ -115,14 +115,8 @@ jobs:
           git status
           git add -A
           git commit -m "Update docs"
-          if git diff-index --quiet HEAD
-            then
-              git tag ${{ github.event.inputs.release-version }} HEAD
-              git push --follow-tags
-            else
-              echo "[!] No changes detected. Exiting....."
-              exit 1
-          fi
+          git tag ${{ github.event.inputs.release-version }} HEAD
+          git push --follow-tags
 
       -
         name: Run GoReleaser

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ git config --global --add safe.directory [your dir here]
 
 ### Create a new version
 
-Create a tag on a commit with the following format `v{marjor}.{minor}.{patch}`; i.e.: v0.4.0; this will create a version accordingly.
+1. Go to the `Actions` tab of this repository.
+2. In the left side plane, click on `Terraform Provider Release Deployer` workflow.
+3. This will open the workflow window. Now click on the `Run workflow` dropdown.
+4. You'll now be presented with 2 selection boxes.
+5. The first box allows you to choose the `release version` you wish to deploy. Please make sure it is in the format `v{marjor}.{minor}.{patch}`; i.e.: v0.4.0
+6. The second box allows you to define `release version type` like what kind of version you are deploying i.e. is it a patch release, a minor one or a major one.
+
 It will create a release in github and push this version to the Terraform Registry (see [Terraform](https://registry.terraform.io/providers/leanspace/leanspace/latest)).
 
 ### Run the plugin

--- a/scripts/version-incrementer.sh
+++ b/scripts/version-incrementer.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Increment a version string using Semantic Versioning (SemVer) terminology.
+
+# Parse command line options.
+
+while getopts ":Mmp" Option
+do
+  case $Option in
+    M ) major=true;;
+    m ) minor=true;;
+    p ) patch=true;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+version=$1
+
+# Build array from version string.
+
+a=( ${version//./ } )
+
+# If version string is missing or has the wrong number of members, show usage message.
+
+if [ ${#a[@]} -ne 3 ]
+then
+  echo "usage: $(basename $0) [-Mmp] major.minor.patch"
+  exit 1
+fi
+
+# Increment version numbers as requested.
+
+if [ ! -z $major ]
+then
+  ((a[0]++))
+  a[1]=0
+  a[2]=0
+fi
+
+if [ ! -z $minor ]
+then
+  ((a[1]++))
+  a[2]=0
+fi
+
+if [ ! -z $patch ]
+then
+  ((a[2]++))
+fi
+
+echo "${a[0]}.${a[1]}.${a[2]}"


### PR DESCRIPTION
- In this PR, I've added release version validation for terraform releases.
- This PR now makes it possible to deploy terraform release with an automated workflow without the need of tagging commits. You simply need to specify the version you wish to release and the type of release whether major, minor or patch.
- Everytime the workflow is executed, 2 jobs will be run by it:

  `version-validation`:
    - This job validates the provided release version and checks if it complies with the format.
    - It also checks if it matches the release type provided. For example, the last release version was `v0.8.4` and you are now releasing a new patch, it will check if the new patch version is `v0.8.5`.
    - The script `version-incrementer.sh` is used for generating the next incremental version.

  `release-deployer`:
    - This is where the actual deployment is performed which mostly remains the same as before with a change of tagging the newly committed code generated by `Generate Documentation` step to allow the `GoReleaser` to detect it.
    - At the end, it updates the action variable `RELEASE_VERSION` with the newly deployed release version. This is also where you can check for the latest deployed release version.
