### PR TITLE
SDEVOPS-358 - Added dependency condition for release-deployer job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
           esac
 
   release-deployer:
+    needs: version-validation
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
- Added the `needs` condition to `release-deployer` job to make sure it only gets triggered if `version-validation` job succeeds.