### PR TITLE
SDEVOPS-365 - Added approval step to terraform release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,13 @@ jobs:
     needs: version-validation
     runs-on: ubuntu-latest
     steps:
+      - 
+        name: Terraform Release Approval
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: elodietinland,jerome-leanspace
+          minimum-approvals: 1
       -
         name: Checkout local repo
         uses: actions/checkout@v3


### PR DESCRIPTION
- Changes made in this PR will ensure that before new versions of terraform repository are released to the customers, either @jerome-leanspace or @elodietinland would have to approve the release to allow it to be deployed.