### PR TITLE
BUZZ-370: support custom environment + region

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The attributes are as follows:
 - tenant: mandatory
 - env: optional
 - host: optional
+- region: optional
 - client_id: mandatory, refers to the client id of a service account
 - client_secret: mandatory, refers to the client secret of a service account
 
@@ -95,6 +96,7 @@ This service account needs to have enough permissions (CRUD).
 It is also possible to avoid passing this information in the provider by using environment variables as follows:
 - TENANT
 - ENV
+- REGION
 - HOST
 - CLIENT_ID
 - CLIENT_SECRET
@@ -140,10 +142,17 @@ The available resources per service are:
 - monitors:
   - action_templates: it has one simple `leanspace_action_template` with a body and headers
   - monitors: it has two `leanspace_monitors`, one with and one without a tolerance set.
+- orbits:
+  - orbit_resources: it has one simple `leanspace_orbit_resources` with a body and headers
+- pass:
+  - pass_states: it has one `leanspace_pass_states` resource.
 - plans:
   - plan_states: it has one `leanspace_plan_states` resource.
 - plugins:
   - plugins: it has one `leanspace_plugins` resource, with basic filler data.
+- routes:
+  - processors: it has one `leanspace_processors` resource, with basic filler data.
+  - routes: it has one `leanspace_routes` resource, with basic filler data.
 - streams:
   - streams: it has one `leanspace_streams` resource, with all available element types (3), all possible field types (5), a computed field and a mapping.
 - teams:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The attributes are as follows:
 - tenant: mandatory
 - env: optional
 - host: optional
-- region: optional
+- region: optional (defaults to `eu-central-1`)
 - client_id: mandatory, refers to the client id of a service account
 - client_secret: mandatory, refers to the client secret of a service account
 

--- a/provider/client.go
+++ b/provider/client.go
@@ -36,13 +36,9 @@ type AuthResponse struct {
 }
 
 func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Client, error) {
-	if env == nil || *env == "" {
-		environment := "prod"
-		env = &environment
-	}
 	hostUrl := "https://api.leanspace.io"
 	switch *env {
-	case "", "prod":
+	case "prod":
 		hostUrl = "https://api.leanspace.io"
 	default:
 		hostUrl = fmt.Sprintf("https://api.%s.leanspace.io", *env)
@@ -55,11 +51,6 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 
 	if host != nil && *host != "" {
 		c.HostURL = *host
-	}
-
-	if region == nil || *region == "" {
-		currentRegion := "eu-central-1"
-		region = &currentRegion
 	}
 
 	// If tenant, clientId or clientSecret not provided, return empty client

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -29,13 +29,13 @@ func Provider() *schema.Provider {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("REGION", nil),
+				DefaultFunc: schema.EnvDefaultFunc("REGION", "eu-central-1"),
 				Description: "Only set this value if you are using a specific region given by leanspace",
 			},
 			"env": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ENV", nil),
+				DefaultFunc: schema.EnvDefaultFunc("ENV", "prod"),
 				Description: "Only set this value if you are using a specific environment given by leanspace",
 			},
 			"tenant": {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -26,6 +26,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("HOST", nil),
 				Description: "Only set this value if you are using a specific URL given by leanspace",
 			},
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REGION", nil),
+				Description: "Only set this value if you are using a specific region given by leanspace",
+			},
 			"env": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -64,12 +70,13 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	tenant := d.Get("tenant").(string)
 	clientId := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
+	region := d.Get("region").(string)
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
 	if (clientId != "") && (clientSecret != "") && (tenant != "") {
-		c, err := NewClient(&host, &env, &tenant, &clientId, &clientSecret)
+		c, err := NewClient(&host, &env, &tenant, &clientId, &clientSecret, &region)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -77,7 +84,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 		return c, diags
 	}
 
-	c, err := NewClient(nil, nil, nil, nil, nil)
+	c, err := NewClient(nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}


### PR DESCRIPTION
Right now a custom host can be set but with this way we can just use the environment to deduce the api address, the host still takes priority and can be used to test locally
Region was not supported, this adds the possibility to specify the region --> an alternative would be to deduce it from the tenants api: https://api.leanspace.io/tenants-repository/swagger-ui/index.html?configUrl=/tenants-repository/v3/api-docs/swagger-config#/tenants-controller/getByTenantKey --> What do you think?

Depending on Pritesh's finding this PR may change