### PR TITLE
BUZZ-000: fix access policy's action's order

### DIFF
--- a/services/teams/access_policies/parsers.go
+++ b/services/teams/access_policies/parsers.go
@@ -1,6 +1,9 @@
 package access_policies
 
-import "github.com/leanspace/terraform-provider-leanspace/helper"
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/leanspace/terraform-provider-leanspace/helper"
+)
 
 func (policy *AccessPolicy) ToMap() map[string]any {
 	policyMap := make(map[string]any)
@@ -44,8 +47,8 @@ func (policy *AccessPolicy) FromMap(policyMap map[string]any) error {
 
 func (statement *Statement) FromMap(statementMap map[string]any) error {
 	statement.Name = statementMap["name"].(string)
-	statement.Actions = make([]string, len(statementMap["actions"].([]any)))
-	for i, action := range statementMap["actions"].([]any) {
+	statement.Actions = make([]string, len(statementMap["actions"].(*schema.Set).List()))
+	for i, action := range statementMap["actions"].(*schema.Set).List() {
 		statement.Actions[i] = action.(string)
 	}
 	return nil

--- a/services/teams/access_policies/parsers.go
+++ b/services/teams/access_policies/parsers.go
@@ -32,7 +32,7 @@ func (policy *AccessPolicy) FromMap(policyMap map[string]any) error {
 	policy.Name = policyMap["name"].(string)
 	policy.Description = policyMap["description"].(string)
 	policy.ReadOnly = policyMap["read_only"].(bool)
-	if statements, err := helper.ParseFromMaps[Statement](policyMap["statements"].([]any)); err != nil {
+	if statements, err := helper.ParseFromMaps[Statement](policyMap["statements"].(*schema.Set).List()); err != nil {
 		return err
 	} else {
 		policy.Statements = statements

--- a/services/teams/access_policies/schemas.go
+++ b/services/teams/access_policies/schemas.go
@@ -25,7 +25,7 @@ var accessPolicySchema = map[string]*schema.Schema{
 		Computed: true,
 	},
 	"statements": {
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: statementSchema,

--- a/services/teams/access_policies/schemas.go
+++ b/services/teams/access_policies/schemas.go
@@ -61,7 +61,7 @@ var statementSchema = map[string]*schema.Schema{
 		Required: true,
 	},
 	"actions": {
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Required: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,


### PR DESCRIPTION
It seems actions of an Access Policies are automatically reorderd by the API
This fixes the issue were terraform detects a change because we don't have the same order

Edit: cc @kbudkaLeanspace Can you confirm that this is an expected behaviour? --> It is confirmed that the API reorders actions alphabetically but also the statements per name