### PR TITLE
BUZZ-000: add a timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
     steps:
       - name: Terraform Release Approval
         uses: trstringer/manual-approval@v1
+        timeout-minutes: 15
         with:
           secret: ${{ github.TOKEN }}
           approvers: elodietinland,jerome-leanspace,coutinol,kbudkaLeanspace,FlorianLacour,leanspace-thomas


### PR DESCRIPTION
This is to avoid such "issue": https://github.com/leanspace/terraform-provider-leanspace/actions/runs/6504976466/job/17667778091

I haven't tested it but from the docs it says it kills it so I suspect the following tasks will not be done, right?