### PR TITLE
BUZZ-428: command's definition's identifier should be optional

### DIFF
--- a/services/commands/command_definitions/schemas.go
+++ b/services/commands/command_definitions/schemas.go
@@ -101,7 +101,7 @@ var argumentSchema = map[string]*schema.Schema{
 	},
 	"identifier": {
 		Type:     schema.TypeString,
-		Required: true,
+		Optional: true,
 	},
 	"description": {
 		Type:     schema.TypeString,


### PR DESCRIPTION
This fixes a pending issue where the identifier was considered as required instead of optional

Another change (bigger) will come later to support the issue of Quantum (changing the argument/metadata is not working)