### PR TITLE
BUZZ-446: increase stream maximum depth

### DIFF
--- a/services/streams/streams/schemas.go
+++ b/services/streams/streams/schemas.go
@@ -103,7 +103,7 @@ var configurationSchema = map[string]*schema.Schema{
 		MinItems: 1,
 		Elem: &schema.Resource{
 			// Arbitrary depth
-			Schema: elementListSchema(streamComponentSchema(5)),
+			Schema: elementListSchema(streamComponentSchema(11)),
 		},
 	},
 	"metadata": {


### PR DESCRIPTION
Increased maximum depth from 5 to 11. 11 is required for Sateliot Demo.
We should think of a better long term solution but the higher the depth, the longer it may take for terraform to process a stream resource.