### PR TITLE
BUZZ-447: increase timeout

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -45,7 +45,7 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 	}
 
 	c := Client{
-		HTTPClient: &http.Client{Timeout: 120 * time.Second},
+		HTTPClient: &http.Client{Timeout: 300 * time.Second},
 		HostURL:    hostUrl,
 	}
 


### PR DESCRIPTION
Mainly for plugins/processors, the timeout can be short.
We imagine the customer has fiber optics, with this someone can upload 10 (default parallelism for our terraform provider) processors or plugins with the maximum size (250 MB) with a 66Mb/s (previously 166Mb/s) connection.
For a file at a time it requires a 6,6 Mb/s (16Mb/s previously) connection which should be available to most customers.

There's a possibility to create a resource without a timeout but it requires some change in the code, which I don't believe is necessary
Let me know if you think of another value for the timeout.