### PR TITLE
BLUE-1648 update ideal orbit schemas with respect to newly introduced constraints

### DIFF
--- a/helper/validation.go
+++ b/helper/validation.go
@@ -410,3 +410,20 @@ func isValidVersion(value string) (v int64, ok bool) {
 	}
 	return 0, false
 }
+
+func FloatAtLeastAndLessThan(min, maxExclusive float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float64", k))
+			return
+		}
+
+		if v < min || v >= maxExclusive {
+			es = append(es, fmt.Errorf("expected %s to be at equal or greater than %f and strictly less than %f, got %f", k, min, maxExclusive, v))
+			return
+		}
+
+		return
+	}
+}

--- a/services/orbits/orbits/schemas.go
+++ b/services/orbits/orbits/schemas.go
@@ -67,22 +67,27 @@ var idealOrbitSchema = map[string]*schema.Schema{
 	"inclination": {
 		Type:     schema.TypeFloat,
 		Required: true,
+		ValidateFunc: validation.FloatBetween(0.0, 180.0),
 	},
 	"right_ascension_of_ascending_node": {
 		Type:     schema.TypeFloat,
 		Required: true,
+		ValidateFunc: validation.FloatBetween(0.0, 360.0),
 	},
 	"argument_of_perigee": {
 		Type:     schema.TypeFloat,
 		Required: true,
+		ValidateFunc: validation.FloatBetween(0.0, 360.0),
 	},
 	"altitude_in_meters": {
 		Type:     schema.TypeFloat,
 		Required: true,
+		ValidateFunc: validation.FloatAtLeast(0.0),
 	},
 	"eccentricity": {
 		Type:     schema.TypeFloat,
 		Required: true,
+		ValidateFunc: helper.FloatAtLeastAndLessThan(0.0, 1.0),
 	},
 	"perigee_altitude_in_meters": {
 		Type:     schema.TypeFloat,

--- a/testing/orbits/orbits/main.tf
+++ b/testing/orbits/orbits/main.tf
@@ -32,7 +32,7 @@ resource "leanspace_orbits" "an_orbit" {
     right_ascension_of_ascending_node = 50.0
     argument_of_perigee               = 0.8
     altitude_in_meters                = 150.0
-    eccentricity                      = 0.7
+    eccentricity                      = 0.999
   }
   tags {
     key   = "Mission"


### PR DESCRIPTION
see also https://github.com/leanspace/integration-testing/pull/463 & https://github.com/leanspace/orbits-repository/pull/89