### PR TITLE
GOLDS-666: don't check order for processors in routes

### DIFF
--- a/services/routes/routes/parsers.go
+++ b/services/routes/routes/parsers.go
@@ -69,8 +69,8 @@ func (route *Route) FromMap(routeMap map[string]any) error {
 			return err
 		}
 	}
-	route.ProcessorIds = make([]string, len(routeMap["processor_ids"].([]any)))
-	for i, processorId := range routeMap["processor_ids"].([]any) {
+	route.ProcessorIds = make([]string, len(routeMap["processor_ids"].(*schema.Set).List()))
+	for i, processorId := range routeMap["processor_ids"].(*schema.Set).List() {
 		route.ProcessorIds[i] = processorId.(string)
 	}
 	route.CreatedAt = routeMap["created_at"].(string)

--- a/services/routes/routes/schemas.go
+++ b/services/routes/routes/schemas.go
@@ -44,7 +44,7 @@ var routeSchema = map[string]*schema.Schema{
 	},
 
 	"processor_ids": {
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Optional: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,


### PR DESCRIPTION
Changing from List to Set so it doesn't check the order anymore