### PR TITLE
BUZZ-000: refresh token before it expires

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -75,10 +75,10 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 	}
 
 	c.Token = ar.Token
-	scheduledTime := time.Duration(ar.ExpiresIn)*time.Second - 2*time.Minute // schedule before to avoid 401 between refresh
+	scheduledTime := time.Duration(ar.ExpiresIn)*time.Second - 2*time.Minute // schedule token refresh before expiration to avoid 401 while the token refreshes
 	go func(scheduledTime time.Duration) {
 		ticker := time.NewTicker(scheduledTime)
-		defer ticker.Stop()  // should never stop
+		defer ticker.Stop()  // should never be called as we never exit the function
 		for range ticker.C { // enters at each scheduledTime
 			authResponse, err := c.SignIn()
 			if err != nil {

--- a/provider/client.go
+++ b/provider/client.go
@@ -75,6 +75,10 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 	}
 
 	c.Token = ar.Token
+	time.AfterFunc(58*time.Minute, func() {
+		newClient, _ := NewClient(host, env, tenant, clientId, clientSecret, region)
+		c = *newClient
+	})
 
 	return &c, nil
 }

--- a/provider/client.go
+++ b/provider/client.go
@@ -75,7 +75,8 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 	}
 
 	c.Token = ar.Token
-	time.AfterFunc(58*time.Minute, func() {
+	scheduledTime := time.Duration(ar.ExpiresIn)*time.Second - 2*time.Minute
+	time.AfterFunc(scheduledTime, func() {
 		newClient, _ := NewClient(host, env, tenant, clientId, clientSecret, region)
 		c = *newClient
 	})

--- a/provider/client.go
+++ b/provider/client.go
@@ -75,11 +75,11 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 	}
 
 	c.Token = ar.Token
-	scheduledTime := time.Duration(ar.ExpiresIn)*time.Second - 2*time.Minute
+	scheduledTime := time.Duration(ar.ExpiresIn)*time.Second - 2*time.Minute // schedule before to avoid 401 between refresh
 	go func(scheduledTime time.Duration) {
 		ticker := time.NewTicker(scheduledTime)
-		defer ticker.Stop()
-		for range ticker.C {
+		defer ticker.Stop()  // should never stop
+		for range ticker.C { // enters at each scheduledTime
 			authResponse, err := c.SignIn()
 			if err != nil {
 				return


### PR DESCRIPTION
When using terraform with a high number of resources (either creation, update or even deletion), the token is only valid for 1 hour. When the token expires it still tries to do the remaining operations which can still take some time. You see that some/most of the resources were not created but only after every API calls are made.
This PR automatically refreshes the token before the expiration of the token.