### PR TITLE
BUZZ-731: use new endpoint to get token

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -97,16 +97,14 @@ func (c *Client) SignIn() (*AuthResponse, error) {
 		return nil, fmt.Errorf("define client id and client secret")
 	}
 
-	cognitoURL := fmt.Sprintf("https://%s-%s.auth.%s.amazoncognito.com/oauth2/token?scope=https://api.leanspace.io/READ&grant_type=client_credentials", c.Auth.Tenant, c.Auth.Env, c.Auth.Region)
-	if strings.HasPrefix(c.Auth.Region, "us-gov") {
-		cognitoURL = fmt.Sprintf("https://%s-%s.auth-fips.%s.amazoncognito.com/oauth2/token?scope=https://api.leanspace.io/READ&grant_type=client_credentials", c.Auth.Tenant, c.Auth.Env, c.Auth.Region)
-	}
+	tokenUrl := fmt.Sprintf("%s/teams-repository/oauth2/token?tenant=%s", c.HostURL, c.Auth.Tenant)
 
-	req, err := http.NewRequest("POST", cognitoURL, strings.NewReader("Content-Type=application%2Fx-www-form-urlencoded"))
+	payload := strings.NewReader(fmt.Sprintf("client_id=%s&client_secret=%s&grant_type=client_credentials", c.Auth.ClientId, c.Auth.ClientSecret))
+
+	req, err := http.NewRequest("POST", tokenUrl, payload)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Authorization", "Basic "+basicAuth(c.Auth.ClientId, c.Auth.ClientSecret))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	body, err, _ := c.DoRequest(req, nil)

--- a/testing/records/record_templates/main.tf
+++ b/testing/records/record_templates/main.tf
@@ -6,13 +6,6 @@ terraform {
   }
 }
 
-provider "leanspace" {
-  env           = "develop"
-  tenant        = "yuri"
-  client_id     = "4a4e5cnf4i11rmes6albkqa1st"
-  client_secret = "iudp3kn5htosttt11h6753dog6qfvejjs4ge0kmbu93n0d5iju0"
-}
-
 variable "node_id" {
   type        = string
   description = "The ID of the node to which the resource will be added."


### PR DESCRIPTION
With this change terraform will use the new endpoint to retrieve the token