### PR TITLE
Fix/golds 664 routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository enables the use of Terraform for the different services of Leans
 
 ## Requirements
 
-- terraform (`choco install terraform` (windows) or `brew install terraform` (mac)): >=1.5.0
-- go (for plugin development): >=1.20
+- terraform (`choco install terraform` (windows) or `brew install hashicorp/tap/terraform` (mac)): >=1.5.0
+- go (for plugin development): >=1.22
 
 ## Supported platform
 
@@ -49,7 +49,6 @@ These platforms are defined in `.goreleaser.yml`.
 }
 ```
 
-- Compile your code by doing `make install -e DEBUG=true`
 - In VSCode, start "Debug Terraform Provider"
 - It will output something like `TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}'` in the Debug Console Tab
 - Export this variable by doing `export TF_REATTACH_PROVIDERS=[...]`

--- a/provider/generic_client.go
+++ b/provider/generic_client.go
@@ -229,6 +229,11 @@ func (client GenericClient[T, PT]) Update(elementId string, updateElement PT) (P
 }
 
 func (client GenericClient[T, PT]) Delete(elementId string, element PT) error {
+	if preDelete, ok := any(element).(PreDeleteModel); ok {
+		if err := preDelete.PreDeleteProcess(client.Client, element); err != nil {
+			return err
+		}
+	}
 	path := fmt.Sprintf("%s/%s", client.Path, elementId)
 	if client.DeletePath != nil {
 		path = client.DeletePath(elementId)

--- a/provider/parser_mapping.go
+++ b/provider/parser_mapping.go
@@ -56,6 +56,13 @@ type PostUpdateModel interface {
 	PostUpdateProcess(*Client, any) error
 }
 
+type PreDeleteModel interface {
+	// An optional extra function that is called before this instance was delete remotely by terraform.
+	// Extra requests (e.g. detaching linked entity) can be done here to allow for the deletion of the resource,
+	// as this method is exclusively called before the resource is deleted..
+	PreDeleteProcess(*Client, any) error
+}
+
 type PostDeleteModel interface {
 	// An optional extra function that is called after this instance was delete remotely by terraform.
 	// Extra requests (e.g. a cleanup) can be done here, as this method is exclusively called after the resource

--- a/services/routes/processors/models.go
+++ b/services/routes/processors/models.go
@@ -19,4 +19,12 @@ type ProcessorUrl struct {
 	Expires string `json:"expires"`
 }
 
+type AttachedRoute struct {
+	Content []AttachedRouteContent `json:"content"`
+}
+
+type AttachedRouteContent struct {
+	ID string `json:"id"`
+}
+
 func (processor *Processor) GetID() string { return processor.ID }


### PR DESCRIPTION
Feat:
- Add a new interface and method that can be called before the deletion happens: This method is used to detach the processor from all the routes --> The processor is automatically reattached because the Route resource is seen as needing modification

Issue:
- This works "too" well and it will also remove the processor from linked routes even when it's a "normal" deletion
  - It seems there is no way to differentiate between a "normal" deletion or a deletion as part of the deletion+creation flow (when we want to update the processor)
  - I'm open to suggestion here, maybe @N1ark has an idea?