### PR TITLE
BUZZ-639: allow triggerOn on action template's linking

### DIFF
--- a/services/monitors/action_templates/main.go
+++ b/services/monitors/action_templates/main.go
@@ -5,6 +5,6 @@ import "github.com/leanspace/terraform-provider-leanspace/provider"
 var ActionTemplateDataType = provider.DataSourceType[ActionTemplate, *ActionTemplate]{
 	ResourceIdentifier: "leanspace_action_templates",
 	Path:               "monitors-repository/action-templates",
-	Schema:             ActionTemplateSchema,
+	Schema:             baseActionTemplateSchema,
 	FilterSchema:       dataSourceFilterSchema,
 }

--- a/services/monitors/action_templates/schemas.go
+++ b/services/monitors/action_templates/schemas.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var validTypes = []string{"WEBHOOK"}
+var ValidTypes = []string{"WEBHOOK"}
 
 var ActionTemplateSchema = map[string]*schema.Schema{
 	"id": {
@@ -22,8 +22,8 @@ var ActionTemplateSchema = map[string]*schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
 		Default:      "WEBHOOK",
-		ValidateFunc: validation.StringInSlice(validTypes, false),
-		Description:  helper.AllowedValuesToDescription(validTypes),
+		ValidateFunc: validation.StringInSlice(ValidTypes, false),
+		Description:  helper.AllowedValuesToDescription(ValidTypes),
 	},
 	"url": {
 		Type:         schema.TypeString,
@@ -70,8 +70,8 @@ var dataSourceFilterSchema = map[string]*schema.Schema{
 		Optional: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validation.StringInSlice(validTypes, false),
-			Description:  helper.AllowedValuesToDescription(validTypes),
+			ValidateFunc: validation.StringInSlice(ValidTypes, false),
+			Description:  helper.AllowedValuesToDescription(ValidTypes),
 		},
 	},
 	"monitor_ids": {

--- a/services/monitors/action_templates/schemas.go
+++ b/services/monitors/action_templates/schemas.go
@@ -7,61 +7,84 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var ValidTypes = []string{"WEBHOOK"}
+var validTypes = []string{"WEBHOOK"}
 
-var ActionTemplateSchema = map[string]*schema.Schema{
-	"id": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"name": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"type": {
-		Type:         schema.TypeString,
-		Optional:     true,
-		Default:      "WEBHOOK",
-		ValidateFunc: validation.StringInSlice(ValidTypes, false),
-		Description:  helper.AllowedValuesToDescription(ValidTypes),
-	},
-	"url": {
-		Type:         schema.TypeString,
-		Required:     true,
-		ValidateFunc: validation.IsURLWithHTTPorHTTPS,
-	},
-	"payload": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"headers": {
-		Type:     schema.TypeMap,
-		Optional: true,
-		Default:  make(map[string]string),
-		Elem: &schema.Schema{
-			Type: schema.TypeString,
+var ValidTriggeredOn = []string{
+	"TRIGGERED",
+	"OK",
+}
+
+var baseActionTemplateSchema = MakeActionTemplateSchema(false)
+
+func MakeActionTemplateSchema(includeTriggeredOn bool) map[string]*schema.Schema {
+	baseSchema := map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
 		},
-	},
-	"created_at": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "When it was created",
-	},
-	"created_by": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Who created it",
-	},
-	"last_modified_at": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "When it was last modified",
-	},
-	"last_modified_by": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Who modified it the last",
-	},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "WEBHOOK",
+			ValidateFunc: validation.StringInSlice(validTypes, false),
+			Description:  helper.AllowedValuesToDescription(validTypes),
+		},
+		"url": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+		"payload": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"headers": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Default:  make(map[string]string),
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"created_at": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "When it was created",
+		},
+		"created_by": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Who created it",
+		},
+		"last_modified_at": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "When it was last modified",
+		},
+		"last_modified_by": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Who modified it the last",
+		},
+	}
+
+	if includeTriggeredOn {
+		baseSchema["triggered_on"] = &schema.Schema{
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice(ValidTriggeredOn, false),
+				Description:  helper.AllowedValuesToDescription(ValidTriggeredOn),
+			},
+		}
+	}
+
+	return baseSchema
 }
 
 var dataSourceFilterSchema = map[string]*schema.Schema{
@@ -70,8 +93,8 @@ var dataSourceFilterSchema = map[string]*schema.Schema{
 		Optional: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validation.StringInSlice(ValidTypes, false),
-			Description:  helper.AllowedValuesToDescription(ValidTypes),
+			ValidateFunc: validation.StringInSlice(validTypes, false),
+			Description:  helper.AllowedValuesToDescription(validTypes),
 		},
 	},
 	"monitor_ids": {

--- a/services/monitors/monitors/models.go
+++ b/services/monitors/monitors/models.go
@@ -2,24 +2,23 @@ package monitors
 
 import (
 	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
-	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
 )
 
 type Monitor struct {
-	ID                string                            `json:"id"`
-	Name              string                            `json:"name"`
-	Description       string                            `json:"description"`
-	Status            string                            `json:"status"`
-	MetricId          string                            `json:"metricId"`
-	NodeId            string                            `json:"nodeId"`
-	Rule              Rule                              `json:"rule"`
-	ActionTemplates   []action_templates.ActionTemplate `json:"actionTemplates"`
-	ActionTemplateIds []string                          `json:"actionTemplateIds"`
-	Tags              []general_objects.KeyValue        `json:"tags"`
-	CreatedAt         string                            `json:"createdAt"`
-	CreatedBy         string                            `json:"createdBy"`
-	LastModifiedAt    string                            `json:"lastModifiedAt"`
-	LastModifiedBy    string                            `json:"lastModifiedBy"`
+	ID                  string                     `json:"id"`
+	Name                string                     `json:"name"`
+	Description         string                     `json:"description"`
+	Status              string                     `json:"status"`
+	MetricId            string                     `json:"metricId"`
+	NodeId              string                     `json:"nodeId"`
+	Rule                Rule                       `json:"rule"`
+	ActionTemplates     []ActionTemplate           `json:"actionTemplates"`
+	ActionTemplateLinks []ActionTemplateLink       `json:"actionTemplateLinks"`
+	Tags                []general_objects.KeyValue `json:"tags"`
+	CreatedAt           string                     `json:"createdAt"`
+	CreatedBy           string                     `json:"createdBy"`
+	LastModifiedAt      string                     `json:"lastModifiedAt"`
+	LastModifiedBy      string                     `json:"lastModifiedBy"`
 }
 
 func (monitor *Monitor) GetID() string { return monitor.ID }
@@ -28,4 +27,23 @@ type Rule struct {
 	ComparisonOperator string  `json:"comparisonOperator"`
 	ComparisonValue    float64 `json:"comparisonValue"`
 	Tolerance          float64 `json:"tolerance,omitempty"`
+}
+
+type ActionTemplateLink struct {
+	ID          string   `json:"id"`
+	TriggeredOn []string `json:"triggeredOn"`
+}
+
+type ActionTemplate struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Type           string            `json:"type"`
+	URL            string            `json:"url"`
+	Payload        string            `json:"payload"`
+	Headers        map[string]string `json:"headers"`
+	TriggeredOn    []string          `json:"triggeredOn"`
+	CreatedAt      string            `json:"createdAt"`
+	CreatedBy      string            `json:"createdBy"`
+	LastModifiedAt string            `json:"lastModifiedAt"`
+	LastModifiedBy string            `json:"lastModifiedBy"`
 }

--- a/services/monitors/monitors/parsers.go
+++ b/services/monitors/monitors/parsers.go
@@ -3,7 +3,6 @@ package monitors
 import (
 	"github.com/leanspace/terraform-provider-leanspace/helper"
 	"github.com/leanspace/terraform-provider-leanspace/helper/general_objects"
-	"github.com/leanspace/terraform-provider-leanspace/services/monitors/action_templates"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -18,7 +17,9 @@ func (monitor *Monitor) ToMap() map[string]any {
 	monitorMap["node_id"] = monitor.NodeId
 	monitorMap["rule"] = []any{monitor.Rule.ToMap()}
 	monitorMap["action_templates"] = helper.ParseToMaps(monitor.ActionTemplates)
-	monitorMap["action_template_ids"] = monitor.ActionTemplateIds
+	if monitor.ActionTemplateLinks != nil {
+		monitorMap["action_template_links"] = helper.ParseToMaps(monitor.ActionTemplateLinks)
+	}
 	monitorMap["tags"] = helper.ParseToMaps(monitor.Tags)
 	monitorMap["created_at"] = monitor.CreatedAt
 	monitorMap["created_by"] = monitor.CreatedBy
@@ -36,6 +37,13 @@ func (rule *Rule) ToMap() map[string]any {
 	return ruleMap
 }
 
+func (actionTemplateLink *ActionTemplateLink) ToMap() map[string]any {
+	actionTemplateLinkMap := make(map[string]any)
+	actionTemplateLinkMap["id"] = actionTemplateLink.ID
+	actionTemplateLinkMap["triggered_on"] = actionTemplateLink.TriggeredOn
+	return actionTemplateLinkMap
+}
+
 func (monitor *Monitor) FromMap(monitorMap map[string]any) error {
 	monitor.ID = monitorMap["id"].(string)
 	monitor.Name = monitorMap["name"].(string)
@@ -48,14 +56,15 @@ func (monitor *Monitor) FromMap(monitorMap map[string]any) error {
 			return err
 		}
 	}
-	if actionTemplates, err := helper.ParseFromMaps[action_templates.ActionTemplate](monitorMap["action_templates"].(*schema.Set).List()); err != nil {
+	if actionTemplates, err := helper.ParseFromMaps[ActionTemplate](monitorMap["action_templates"].(*schema.Set).List()); err != nil {
 		return err
 	} else {
 		monitor.ActionTemplates = actionTemplates
 	}
-	monitor.ActionTemplateIds = make([]string, monitorMap["action_template_ids"].(*schema.Set).Len())
-	for i, value := range monitorMap["action_template_ids"].(*schema.Set).List() {
-		monitor.ActionTemplateIds[i] = value.(string)
+	if actionTemplateLinks, err := helper.ParseFromMaps[ActionTemplateLink](monitorMap["action_template_links"].(*schema.Set).List()); err != nil {
+		return err
+	} else {
+		monitor.ActionTemplateLinks = actionTemplateLinks
 	}
 	if tags, err := helper.ParseFromMaps[general_objects.KeyValue](monitorMap["tags"].(*schema.Set).List()); err != nil {
 		return err
@@ -76,13 +85,60 @@ func (rule *Rule) FromMap(ruleMap map[string]any) error {
 	return nil
 }
 
+func (actionTemplateLink *ActionTemplateLink) FromMap(actionTemplateLinkMap map[string]any) error {
+	actionTemplateLink.ID = actionTemplateLinkMap["id"].(string)
+	actionTemplateLink.TriggeredOn = make([]string, actionTemplateLinkMap["triggered_on"].(*schema.Set).Len())
+	for i, value := range actionTemplateLinkMap["triggered_on"].(*schema.Set).List() {
+		actionTemplateLink.TriggeredOn[i] = value.(string)
+	}
+	return nil
+}
+
 // The API doesn't return "action template IDs", it's a field derived from
 // "actionTemplates" to make it easier to configure.
 // We thus need to persist the IDs in that separate array.
 func (monitor *Monitor) PostUnmarshallProcess() error {
-	monitor.ActionTemplateIds = make([]string, len(monitor.ActionTemplates))
+	monitor.ActionTemplateLinks = make([]ActionTemplateLink, len(monitor.ActionTemplates))
 	for i, value := range monitor.ActionTemplates {
-		monitor.ActionTemplateIds[i] = value.ID
+		monitor.ActionTemplateLinks[i].ID = value.ID
+		monitor.ActionTemplateLinks[i].TriggeredOn = value.TriggeredOn
 	}
+	return nil
+}
+
+func (actionTemplate *ActionTemplate) ToMap() map[string]any {
+	actionTemplateMap := make(map[string]any)
+	actionTemplateMap["id"] = actionTemplate.ID
+	actionTemplateMap["name"] = actionTemplate.Name
+	actionTemplateMap["type"] = actionTemplate.Type
+	actionTemplateMap["url"] = actionTemplate.URL
+	actionTemplateMap["payload"] = actionTemplate.Payload
+	actionTemplateMap["headers"] = actionTemplate.Headers
+	actionTemplateMap["triggered_on"] = actionTemplate.TriggeredOn
+	actionTemplateMap["created_at"] = actionTemplate.CreatedAt
+	actionTemplateMap["created_by"] = actionTemplate.CreatedBy
+	actionTemplateMap["last_modified_at"] = actionTemplate.LastModifiedAt
+	actionTemplateMap["last_modified_by"] = actionTemplate.LastModifiedBy
+	return actionTemplateMap
+}
+
+func (actionTemplate *ActionTemplate) FromMap(actionTemplateMap map[string]any) error {
+	actionTemplate.ID = actionTemplateMap["id"].(string)
+	actionTemplate.Name = actionTemplateMap["name"].(string)
+	actionTemplate.Type = actionTemplateMap["type"].(string)
+	actionTemplate.URL = actionTemplateMap["url"].(string)
+	actionTemplate.Payload = actionTemplateMap["payload"].(string)
+	actionTemplate.Headers = make(map[string]string, len(actionTemplateMap["headers"].(map[string]any)))
+	for key, value := range actionTemplateMap["headers"].(map[string]any) {
+		actionTemplate.Headers[key] = value.(string)
+	}
+	actionTemplate.TriggeredOn = make([]string, actionTemplateMap["triggered_on"].(*schema.Set).Len())
+	for i, value := range actionTemplateMap["triggered_on"].(*schema.Set).List() {
+		actionTemplate.TriggeredOn[i] = value.(string)
+	}
+	actionTemplate.CreatedAt = actionTemplateMap["created_at"].(string)
+	actionTemplate.CreatedBy = actionTemplateMap["created_by"].(string)
+	actionTemplate.LastModifiedAt = actionTemplateMap["last_modified_at"].(string)
+	actionTemplate.LastModifiedBy = actionTemplateMap["last_modified_by"].(string)
 	return nil
 }

--- a/services/monitors/monitors/requests.go
+++ b/services/monitors/monitors/requests.go
@@ -1,19 +1,36 @@
 package monitors
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
-	"github.com/leanspace/terraform-provider-leanspace/helper"
 	"github.com/leanspace/terraform-provider-leanspace/provider"
 )
 
-func (monitor *Monitor) actionTemplateChange(action string, actionTemplateId string, client *provider.Client) error {
-	path := fmt.Sprintf("%s/%s/%s/action-templates/%s", client.HostURL, MonitorDataType.Path, monitor.ID, actionTemplateId)
-	req, err := http.NewRequest(action, path, nil)
+type apiLinkActionTemplate struct {
+	TriggeredOn []string `json:"triggeredOn"`
+}
+
+func (actionTemplateLink *ActionTemplateLink) toAPIFormat() ([]byte, error) {
+	linkActionTemplate := apiLinkActionTemplate{
+		TriggeredOn: actionTemplateLink.TriggeredOn,
+	}
+	return json.Marshal(linkActionTemplate)
+}
+
+func (monitor *Monitor) actionTemplateChange(action string, actionTemplateLink ActionTemplateLink, client *provider.Client) error {
+	data, err := actionTemplateLink.toAPIFormat()
 	if err != nil {
 		return err
 	}
+	path := fmt.Sprintf("%s/%s/%s/action-templates/%s", client.HostURL, MonitorDataType.Path, monitor.ID, actionTemplateLink.ID)
+	req, err := http.NewRequest(action, path, strings.NewReader(string(data)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
 	_, err, _ = client.DoRequest(req, &(client).Token)
 	if err != nil {
 		return err
@@ -21,17 +38,17 @@ func (monitor *Monitor) actionTemplateChange(action string, actionTemplateId str
 	return nil
 }
 
-func (monitor *Monitor) addActionTemplate(actionTemplateId string, client *provider.Client) error {
-	return monitor.actionTemplateChange("POST", actionTemplateId, client)
+func (monitor *Monitor) addActionTemplate(actionTemplateLink ActionTemplateLink, client *provider.Client) error {
+	return monitor.actionTemplateChange("POST", actionTemplateLink, client)
 }
 
-func (monitor *Monitor) removeActionTemplate(actionTemplateId string, client *provider.Client) error {
-	return monitor.actionTemplateChange("DELETE", actionTemplateId, client)
+func (monitor *Monitor) removeActionTemplate(actionTemplateLink ActionTemplateLink, client *provider.Client) error {
+	return monitor.actionTemplateChange("DELETE", actionTemplateLink, client)
 }
 
 func (monitor *Monitor) PostCreateProcess(client *provider.Client, monitorRaw any) error {
 	createdMonitor := monitorRaw.(*Monitor)
-	expectedActionTemplates := monitor.ActionTemplateIds
+	expectedActionTemplates := monitor.ActionTemplateLinks
 
 	// Add all members directly
 	for _, actionTemplate := range expectedActionTemplates {
@@ -46,20 +63,20 @@ func (monitor *Monitor) PostCreateProcess(client *provider.Client, monitorRaw an
 
 func (monitor *Monitor) PostUpdateProcess(client *provider.Client, monitorRaw any) error {
 	monitorCurrent := monitorRaw.(*Monitor)
-	currentActionTemplates := monitorCurrent.ActionTemplateIds
-	expectedActionTemplates := monitor.ActionTemplateIds
+	currentActionTemplates := monitorCurrent.ActionTemplateLinks
+	expectedActionTemplates := monitor.ActionTemplateLinks
 
-	actionTemplatesToRemove := []string{}
-	actionTemplatesToAdd := []string{}
+	actionTemplatesToRemove := []ActionTemplateLink{}
+	actionTemplatesToAdd := []ActionTemplateLink{}
 
 	// Diff action templates to see what to add/remove
 	for _, actionTemplate := range currentActionTemplates {
-		if !helper.Contains(expectedActionTemplates, actionTemplate) {
+		if !contains(expectedActionTemplates, actionTemplate) {
 			actionTemplatesToRemove = append(actionTemplatesToRemove, actionTemplate)
 		}
 	}
 	for _, actionTemplate := range expectedActionTemplates {
-		if !helper.Contains(currentActionTemplates, actionTemplate) {
+		if !contains(currentActionTemplates, actionTemplate) {
 			actionTemplatesToAdd = append(actionTemplatesToAdd, actionTemplate)
 		}
 	}
@@ -83,4 +100,25 @@ func (monitor *Monitor) PostUpdateProcess(client *provider.Client, monitorRaw an
 	}
 
 	return nil
+}
+
+func contains(slice []ActionTemplateLink, value ActionTemplateLink) bool {
+	for _, v := range slice {
+		if v.ID == value.ID && stringSliceAreEqual(v.TriggeredOn, value.TriggeredOn) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceAreEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/services/monitors/monitors/requests.go
+++ b/services/monitors/monitors/requests.go
@@ -21,7 +21,7 @@ func (actionTemplateLink *ActionTemplateLink) toAPIFormat() ([]byte, error) {
 }
 
 func (monitor *Monitor) actionTemplateChange(action string, actionTemplateLink ActionTemplateLink, client *provider.Client) error {
-	data, err := actionTemplateLink.toAPIFormat()
+	data, err := actionTemplateLink.toAPIFormat() // ignored when deleting
 	if err != nil {
 		return err
 	}

--- a/services/monitors/monitors/schemas.go
+++ b/services/monitors/monitors/schemas.go
@@ -19,6 +19,11 @@ var validComparisonOperators = []string{
 	"NOT_EQUAL_TO",
 }
 
+var validTriggeredOn = []string{
+	"TRIGGERED",
+	"OK",
+}
+
 var monitorSchema = map[string]*schema.Schema{
 	"id": {
 		Type:     schema.TypeString,
@@ -58,15 +63,14 @@ var monitorSchema = map[string]*schema.Schema{
 		Type:     schema.TypeSet,
 		Computed: true,
 		Elem: &schema.Resource{
-			Schema: action_templates.ActionTemplateSchema,
+			Schema: actionTemplateSchema,
 		},
 	},
-	"action_template_ids": {
+	"action_template_links": {
 		Type:     schema.TypeSet,
 		Optional: true,
-		Elem: &schema.Schema{
-			Type:         schema.TypeString,
-			ValidateFunc: validation.IsUUID,
+		Elem: &schema.Resource{
+			Schema: actionTemplateLinkSchema,
 		},
 	},
 	"tags": general_objects.KeyValuesSchema,
@@ -97,6 +101,70 @@ var monitorSchema = map[string]*schema.Schema{
 	},
 }
 
+var actionTemplateSchema = map[string]*schema.Schema{
+	"id": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"type": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		Default:      "WEBHOOK",
+		ValidateFunc: validation.StringInSlice(action_templates.ValidTypes, false),
+		Description:  helper.AllowedValuesToDescription(action_templates.ValidTypes),
+	},
+	"url": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+	},
+	"payload": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"headers": {
+		Type:     schema.TypeMap,
+		Optional: true,
+		Default:  make(map[string]string),
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+	"triggered_on": {
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringInSlice(validTriggeredOn, false),
+			Description:  helper.AllowedValuesToDescription(validTriggeredOn),
+		},
+	},
+	"created_at": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "When it was created",
+	},
+	"created_by": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Who created it",
+	},
+	"last_modified_at": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "When it was last modified",
+	},
+	"last_modified_by": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Who modified it the last",
+	},
+}
+
 var ruleSchema = map[string]*schema.Schema{ // ruleSchema
 	"comparison_operator": {
 		Type:         schema.TypeString,
@@ -113,6 +181,24 @@ var ruleSchema = map[string]*schema.Schema{ // ruleSchema
 		Optional:     true,
 		ValidateFunc: validation.FloatAtLeast(0),
 		Description:  "Only valid for EQUAL_TO or NOT_EQUAL_TO comparison operator",
+	},
+}
+
+var actionTemplateLinkSchema = map[string]*schema.Schema{
+	"id": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.IsUUID,
+		Description:  "Identifier of the Action Template",
+	},
+	"triggered_on": {
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringInSlice(validTriggeredOn, false),
+			Description:  helper.AllowedValuesToDescription(validTriggeredOn),
+		},
 	},
 }
 

--- a/services/monitors/monitors/schemas.go
+++ b/services/monitors/monitors/schemas.go
@@ -19,10 +19,7 @@ var validComparisonOperators = []string{
 	"NOT_EQUAL_TO",
 }
 
-var validTriggeredOn = []string{
-	"TRIGGERED",
-	"OK",
-}
+var actionTemplateSchema = action_templates.MakeActionTemplateSchema(true)
 
 var monitorSchema = map[string]*schema.Schema{
 	"id": {
@@ -101,70 +98,6 @@ var monitorSchema = map[string]*schema.Schema{
 	},
 }
 
-var actionTemplateSchema = map[string]*schema.Schema{
-	"id": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"name": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"type": {
-		Type:         schema.TypeString,
-		Optional:     true,
-		Default:      "WEBHOOK",
-		ValidateFunc: validation.StringInSlice(action_templates.ValidTypes, false),
-		Description:  helper.AllowedValuesToDescription(action_templates.ValidTypes),
-	},
-	"url": {
-		Type:         schema.TypeString,
-		Required:     true,
-		ValidateFunc: validation.IsURLWithHTTPorHTTPS,
-	},
-	"payload": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"headers": {
-		Type:     schema.TypeMap,
-		Optional: true,
-		Default:  make(map[string]string),
-		Elem: &schema.Schema{
-			Type: schema.TypeString,
-		},
-	},
-	"triggered_on": {
-		Type:     schema.TypeSet,
-		Optional: true,
-		Elem: &schema.Schema{
-			Type:         schema.TypeString,
-			ValidateFunc: validation.StringInSlice(validTriggeredOn, false),
-			Description:  helper.AllowedValuesToDescription(validTriggeredOn),
-		},
-	},
-	"created_at": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "When it was created",
-	},
-	"created_by": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Who created it",
-	},
-	"last_modified_at": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "When it was last modified",
-	},
-	"last_modified_by": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Who modified it the last",
-	},
-}
-
 var ruleSchema = map[string]*schema.Schema{ // ruleSchema
 	"comparison_operator": {
 		Type:         schema.TypeString,
@@ -196,8 +129,8 @@ var actionTemplateLinkSchema = map[string]*schema.Schema{
 		Optional: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validation.StringInSlice(validTriggeredOn, false),
-			Description:  helper.AllowedValuesToDescription(validTriggeredOn),
+			ValidateFunc: validation.StringInSlice(action_templates.ValidTriggeredOn, false),
+			Description:  helper.AllowedValuesToDescription(action_templates.ValidTriggeredOn),
 		},
 	},
 }


### PR DESCRIPTION
Breaking change:
- renamed `action_template_ids` to `action_template_links`

Feat:
- `action_template_links` contains the id of the action template + `triggeredOn` optionally
- Some duplication due to Go not having inheritance