### PR TITLE
BUZZ-000: allow 64 bits integer in Stream

### DIFF
--- a/examples/resources/leanspace_streams.tf
+++ b/examples/resources/leanspace_streams.tf
@@ -88,7 +88,7 @@ resource "leanspace_streams" "stream" {
     }
     metadata {
       timestamp {
-        expression = "(ctx, raw) => ctx['metadata.received_at'];"
+        expression = "(ctx, raw) => ctx.metadata.received_at;"
       }
     }
     computations {
@@ -96,7 +96,7 @@ resource "leanspace_streams" "stream" {
         data_type  = "UINTEGER"
         name       = "is_version_0"
         expression = <<-EOT
-            (ctx) => ctx['structure.version'] === 0
+            (ctx) => ctx.structure.version === 0
           EOT
       }
       elements {

--- a/services/streams/streams/schemas.go
+++ b/services/streams/streams/schemas.go
@@ -422,7 +422,7 @@ var computationSchema = map[string]*schema.Schema{
 	"expression": {
 		Type:        schema.TypeString,
 		Required:    true,
-		Description: "i.e.: javascript function with 2 input parameters and a return value (ctx, raw) => ctx['metadata.received_at']",
+		Description: "i.e.: javascript function with 2 input parameters and a return value (ctx, raw) => ctx.metadata.received_at",
 	},
 	"valid": {
 		Type:     schema.TypeBool,

--- a/services/streams/streams/validation.go
+++ b/services/streams/streams/validation.go
@@ -19,7 +19,7 @@ var streamComponentValidators = Validators{
 	),
 	If(
 		Or(Equals("data_type", "INTEGER"), Equals("data_type", "UINTEGER")),
-		LessThanEq("length.value", 32),
+		LessThanEq("length.value", 64),
 	),
 	If(
 		Equals("data_type", "DECIMAL"),

--- a/testing/streams/streams/main.tf
+++ b/testing/streams/streams/main.tf
@@ -178,7 +178,7 @@ resource "leanspace_streams" "test" {
     }
     metadata {
       timestamp {
-        expression = "(ctx, raw) => ctx['metadata.received_at'];"
+        expression = "(ctx, raw) => ctx.metadata.received_at;"
       }
     }
     computations {
@@ -187,7 +187,7 @@ resource "leanspace_streams" "test" {
         name       = "power"
         expression = <<-EOT
             (ctx) => {
-              const voltage = ctx['structure.properties.solar_w'];
+              const voltage = ctx.structure.properties.solar_w;
               var power = voltage * 15;
               return (power);
             }


### PR DESCRIPTION
Fix:
- Allow 64 bits integer and unsigned integer since it's now allowed in the API
- Use the "new" format (nested JSON object) everywhere to be consistent