### PR TITLE
BUZZ-000: fail fast when no credentials are supplied

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -84,10 +84,5 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 		return c, diags
 	}
 
-	c, err := NewClient(nil, nil, nil, nil, nil, nil)
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-
-	return c, diags
+	return nil, diag.Errorf("Please provide tenant, client_id and client_secret")
 }


### PR DESCRIPTION
When running terraform on Github action I noticed the following crash. This was caused by a mistake of mine which lead to a variable being empty (empty string).
Empty values were allowed in Terraform for the credentials. This PR removes this possibility and provides a corresponding error message.

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Request cancelled
│ 
│   with provider["registry.terraform.io/leanspace/leanspace"],
│   on main.tf line 9, in provider "leanspace":
│    9: provider "leanspace" {
│ 
│ The plugin.(*GRPCProvider).ConfigureProvider request was cancelled.
╵

Stack trace from the terraform-provider-leanspace_v8.2.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xa9e7c8d]

goroutine 13 [running]:
github.com/leanspace/terraform-provider-leanspace/provider.NewClient(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        github.com/leanspace/terraform-provider-leanspace/provider/client.go:41 +0x4d
github.com/leanspace/terraform-provider-leanspace/provider.providerConfigure({0xaba64b8?, 0x6?}, 0xc0001ce600)
        github.com/leanspace/terraform-provider-leanspace/provider/provider.go:87 +0x28b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).Configure(0xc0003d85a0, {0xaed56e8, 0xc000491380}, 0xc0004ac5f0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/provider.go:306 +0x20d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ConfigureProvider(0xc000464798, {0xaed56e8?, 0xc000490f60?}, 0xc000492390)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/grpc_provider.go:611 +0x39b
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).Configure(0xc000263b80, {0xaed56e8?, 0xc000490720?}, 0xc000526240)
        github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov5/tf5server/server.go:586 +0x2ca
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_Configure_Handler({0xae8d480, 0xc000263b80}, {0xaed56e8, 0xc000490720}, 0xc0001ce000, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:464 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000189000, {0xaed56e8, 0xc000490660}, {0xaedade0, 0xc0003cb040}, 0xc000364240, 0xc000463440, 0xb52b070, 0x0)
        google.golang.org/grpc@v1.62.0/server.go:1383 +0xdd1
google.golang.org/grpc.(*Server).handleStream(0xc000189000, {0xaedade0, 0xc0003cb040}, 0xc000364240)
        google.golang.org/grpc@v1.62.0/server.go:1794 +0xe87
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.62.0/server.go:1027 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 37
        google.golang.org/grpc@v1.62.0/server.go:1038 +0x125

Error: The terraform-provider-leanspace_v8.2.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```