### PR TITLE
BUZZ-000: avoid token expiration

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -85,13 +85,13 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 			if err != nil {
 				errorCount++
 				if errorCount > 5 {
-					panic(err) // avoid infinite loop
+					panic("Token couldn't be refreshed") // avoid infinite loop
 				}
 				ticker.Reset(scheduledTimeIfError) // call sign in earlier in case of error
 				continue
 			} else {
-				ticker.Reset(scheduledTime) // reset to original scheduled time in case it was changed
 				errorCount = 0
+				ticker.Reset(scheduledTime) // reset to original scheduled time in case it was changed
 			}
 			c.Token = authResponse.Token
 		}

--- a/services/requests/feasibility_constraint_definitions/parsers.go
+++ b/services/requests/feasibility_constraint_definitions/parsers.go
@@ -21,7 +21,6 @@ func (feasibilityConstraintDefinition *FeasibilityConstraintDefinition) ToMap() 
 	feasibilityConstraintDefinitionMap["last_modified_at"] = feasibilityConstraintDefinition.LastModifiedAt
 	feasibilityConstraintDefinitionMap["last_modified_by"] = feasibilityConstraintDefinition.LastModifiedBy
 
-	helper.Logger.Printf("%s", feasibilityConstraintDefinitionMap)
 	return feasibilityConstraintDefinitionMap
 }
 

--- a/services/requests/request_definitions/parsers.go
+++ b/services/requests/request_definitions/parsers.go
@@ -30,7 +30,6 @@ func (requestDefinition *RequestDefinition) ToMap() map[string]any {
 	requestDefinitionMap["last_modified_at"] = requestDefinition.LastModifiedAt
 	requestDefinitionMap["last_modified_by"] = requestDefinition.LastModifiedBy
 
-	helper.Logger.Printf("%s", requestDefinitionMap)
 	return requestDefinitionMap
 }
 
@@ -50,7 +49,6 @@ func (feasibilityConstraintDefinition *FeasibilityConstraintDefinition) ToMap() 
 	feasibilityConstraintDefinitionMap["last_modified_at"] = feasibilityConstraintDefinition.LastModifiedAt
 	feasibilityConstraintDefinitionMap["last_modified_by"] = feasibilityConstraintDefinition.LastModifiedBy
 
-	helper.Logger.Printf("%s", feasibilityConstraintDefinitionMap)
 	return feasibilityConstraintDefinitionMap
 }
 


### PR DESCRIPTION
There is a small risk that the renewal of the token fails (network issue, problem on teams, ...). If this happens we did nothing, this could lead to using an expired token and thus having responses with the 401 http code.
To avoid this,  if an error happens it will try to request again the token after 5 seconds (rather than the current 58 minutes) and if there is 6 consecutive errors then a panic is sent and the terraform process with end with the message: ` Error: Request cancelled` (I couldn't modify the message).

Also I removed some unused code and logging.