### PR TITLE
BLUE-2636: allow TIMESTAMP attributes on requests

### DIFF
--- a/examples/resources/leanspace_feasibility_constraint_definitions.tf
+++ b/examples/resources/leanspace_feasibility_constraint_definitions.tf
@@ -2,6 +2,15 @@ resource "leanspace_feasibility_constraint_definitions" "a_feasibility_constrain
   name        = "feasibilityConstraintDefinitionFromTerraform"
   description = "feasibilityConstraintDefinitionTerraformDescription"
   argument_definitions {
+    name        = "TextArgumentDefinition"
+    description = "A text input"
+    attributes {
+      default_value = "hello"
+      type          = "TEXT"
+      required      = true
+    }
+  }
+  argument_definitions {
     name        = "NumericArgumentDefinition"
     description = "A numeric input"
     attributes {
@@ -16,6 +25,15 @@ resource "leanspace_feasibility_constraint_definitions" "a_feasibility_constrain
     attributes {
       default_value = "10:37:19.000"
       type          = "TIME"
+      required      = true
+    }
+  }
+  argument_definitions {
+    name        = "TimestampArgumentDefinition"
+    description = "A timestamp input"
+    attributes {
+      default_value = "2025-07-22T14:54:52.298Z"
+      type          = "TIMESTAMP"
       required      = true
     }
   }

--- a/examples/resources/leanspace_streams.tf
+++ b/examples/resources/leanspace_streams.tf
@@ -12,8 +12,8 @@ resource "leanspace_streams" "stream" {
   name     = "Terraform Stream"
   asset_id = var.asset_id
   tags {
-      key   = "CreatedBy"
-      value = "Terraform"
+    key   = "CreatedBy"
+    value = "Terraform"
   }
 
   configuration {

--- a/services/requests/feasibility_constraint_definitions/schemas.go
+++ b/services/requests/feasibility_constraint_definitions/schemas.go
@@ -62,7 +62,7 @@ var argumentDefinitionSchema = map[string]*schema.Schema{
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: general_objects.DefinitionAttributeSchema(
-				[]string{"BINARY", "BOOLEAN", "ENUM", "TIMESTAMP", "DATE", "ARRAY", "STRUCTURE", "TLE"}, // attribute types not allowed in command definition attributes
+				[]string{"BINARY", "BOOLEAN", "ENUM", "DATE", "ARRAY", "STRUCTURE", "TLE"}, // attribute types not allowed in command definition attributes
 				nil,   // All fields are used
 				false, // Does not force recreation if the type changes
 			),

--- a/services/requests/request_definitions/schemas.go
+++ b/services/requests/request_definitions/schemas.go
@@ -133,7 +133,7 @@ var argumentDefinitionSchema = map[string]*schema.Schema{
 		MaxItems: 499,
 		Elem: &schema.Resource{
 			Schema: general_objects.DefinitionAttributeSchema(
-				[]string{"BINARY", "BOOLEAN", "ENUM", "TIMESTAMP", "DATE", "ARRAY", "STRUCTURE", "TLE"}, // attribute types not allowed in command definition attributes
+				[]string{"BINARY", "BOOLEAN", "ENUM", "DATE", "ARRAY", "STRUCTURE", "TLE"}, // attribute types not allowed in command definition attributes
 				nil,   // All fields are used
 				false, // Does not force recreation if the type changes
 			),
@@ -155,7 +155,7 @@ var computedArgumentDefinitionSchema = map[string]*schema.Schema{
 		Computed: true,
 		Elem: &schema.Resource{
 			Schema: general_objects.DefinitionAttributeSchema(
-				[]string{"BINARY", "BOOLEAN", "ENUM", "TIMESTAMP", "DATE", "ARRAY", "STRUCTURE", "TLE"}, // attribute types not allowed in command definition attributes
+				[]string{"BINARY", "BOOLEAN", "ENUM", "DATE", "ARRAY", "STRUCTURE", "TLE"}, // attribute types not allowed in command definition attributes
 				nil,   // All fields are used
 				false, // Does not force recreation if the type changes
 			),

--- a/testing/requests/feasibility_constraint_definitions/main.tf
+++ b/testing/requests/feasibility_constraint_definitions/main.tf
@@ -47,6 +47,15 @@ resource "leanspace_feasibility_constraint_definitions" "created" {
     }
   }
   argument_definitions {
+    name        = "TimestampArgumentDefinition"
+    description = "A timestamp input"
+    attributes {
+      default_value = "2025-07-22T14:54:52.298Z"
+      type          = "TIMESTAMP"
+      required      = true
+    }
+  }
+  argument_definitions {
     name        = "GeoPointArgumentDefinition"
     description = "A geopoint input"
     attributes {

--- a/testing/streams/streams/main.tf
+++ b/testing/streams/streams/main.tf
@@ -32,8 +32,8 @@ resource "leanspace_streams" "test" {
   description = "A complex stream, entirely created under terraform."
   asset_id    = var.asset_id
   tags {
-      key   = "CreatedBy"
-      value = "Terraform"
+    key   = "CreatedBy"
+    value = "Terraform"
   }
   configuration {
     endianness = "BE"


### PR DESCRIPTION
[prerequisite](https://github.com/leanspace/requests-repository/pull/87)