### PR TITLE
BUZZ-000: correctly map required in element constraint

### DIFF
--- a/helper/general_objects/parsers.go
+++ b/helper/general_objects/parsers.go
@@ -237,6 +237,10 @@ func (attribute *DefinitionAttribute[T]) FromMap(attributeMap map[string]any) er
 
 func (constraint *ArrayConstraint[T]) FromMap(constraintMap map[string]any) error {
 	constraint.Type = constraintMap["type"].(string)
+	if value, ok := constraintMap["required"]; ok {
+		b := value.(bool)
+		constraint.Required = &b
+	}
 	switch constraint.Type {
 	case "NUMERIC":
 		constraint.Min = constraintMap["min"].(float64)


### PR DESCRIPTION
The field `required` was never correctly mapped when present in the constraint of an array argument