### PR TITLE
BLUE-2819: add deprecation note

### DIFF
--- a/services/activities/resource_functions/schemas.go
+++ b/services/activities/resource_functions/schemas.go
@@ -43,6 +43,7 @@ var resourceFunctionSchema = map[string]*schema.Schema{
 	"time_unit": {
 		Type:         schema.TypeString,
 		Optional:     true,
+		Deprecated: "This is replaced by the field time_unit in the formula",
 		ValidateFunc: validation.StringInSlice(validResourceFunctionTimeUnits, false),
 		Description:  helper.AllowedValuesToDescription(validResourceFunctionTimeUnits),
 	},

--- a/testing/events/event_definitions/main.tf
+++ b/testing/events/event_definitions/main.tf
@@ -11,7 +11,7 @@ resource "leanspace_events_definitions" "test" {
   source      = "STREAM_DECODED"
   state       = "ACTIVE"
   description = "A complex event definition, entirely created under terraform."
-  criticality = "TERRAFORM_CRITICALITY"  
+  criticality = "TERRAFORM_CRITICALITY"
   rules {
     operator = "EQUAL_TO"
     path     = "test"

--- a/testing/main.tf
+++ b/testing/main.tf
@@ -32,7 +32,7 @@ module "event_criticalities" {
 
 module "event_definitions" {
   depends_on = [module.event_criticalities]
-  source = "./events/event_definitions"
+  source     = "./events/event_definitions"
 }
 module "command_states" {
   source = "./commands/command_states"


### PR DESCRIPTION
Added a deprecation note as suggested [here](https://github.com/leanspace/terraform-provider-leanspace/pull/259#discussion_r2486957249).

Go documentation : 

<img width="913" height="46" alt="image" src="https://github.com/user-attachments/assets/345418be-59e8-476f-9bd0-8eea39b74128" />

Result of `terraform validate` : 

<img width="1808" height="313" alt="image" src="https://github.com/user-attachments/assets/e0db2180-b3af-4bba-b942-91fa8bff7f80" />
