### PR TITLE
PM-000: add default value for criticality

### DIFF
--- a/services/events/event_definitions/schemas.go
+++ b/services/events/event_definitions/schemas.go
@@ -31,6 +31,7 @@ var eventsDefinitions = map[string]*schema.Schema{
 	"criticality": {
 		Type:     schema.TypeString,
 		Optional: true,
+		Default:  "NORMAL",
 	},
 	"rules": {
 		Type:     schema.TypeSet,


### PR DESCRIPTION
This is made so that no changes are detected by terraform, since the default value is also set by the API.