### PR TITLE
PM-000: remove region as it is not used anymore

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -24,7 +24,6 @@ type AuthStruct struct {
 	Tenant       string `json:"tenant"`
 	ClientId     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
-	Region       string `json:"region"`
 }
 
 // AuthResponse -
@@ -34,7 +33,7 @@ type AuthResponse struct {
 	Token     string `json:"access_token"`
 }
 
-func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Client, error) {
+func NewClient(host, env, tenant, clientId, clientSecret *string) (*Client, error) {
 	hostUrl := "https://api.leanspace.io"
 	switch *env {
 	case "prod":
@@ -64,7 +63,6 @@ func NewClient(host, env, tenant, clientId, clientSecret, region *string) (*Clie
 		Tenant:       *tenant,
 		ClientId:     *clientId,
 		ClientSecret: *clientSecret,
-		Region:       *region,
 	}
 
 	ar, err := c.SignIn()

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -26,12 +26,6 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("HOST", nil),
 				Description: "Only set this value if you are using a specific URL given by leanspace",
 			},
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("REGION", "eu-central-1"),
-				Description: "Only set this value if you are using a specific region given by leanspace",
-			},
 			"env": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -70,13 +64,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	tenant := d.Get("tenant").(string)
 	clientId := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
-	region := d.Get("region").(string)
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
 	if (clientId != "") && (clientSecret != "") && (tenant != "") {
-		c, err := NewClient(&host, &env, &tenant, &clientId, &clientSecret, &region)
+		c, err := NewClient(&host, &env, &tenant, &clientId, &clientSecret)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}


### PR DESCRIPTION
The region was used to fetch the token, this is not needed anymore and can be removed.
For customers having set this value, an error would be thrown like so
```
Error: Unsupported argument
│ 
│   on main.tf line 14, in provider "leanspace":
│   14:   region = "valueOfTheRegion"
│ 
│ An argument named "region" is not expected here.
```